### PR TITLE
Update blog URL to /blog in blog_king_response.html

### DIFF
--- a/blog_king_response.html
+++ b/blog_king_response.html
@@ -10,7 +10,7 @@
     <meta property="og:site_name" content="Echoes of Gaza">
     <meta property="og:title" content="Echoes of Gaza: Blog">
     <meta property="og:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
-    <meta property="og:url" content="https://echoesofgaza.org/blog_king_response.html">
+    <meta property="og:url" content="https://echoesofgaza.org/blog">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="Echoes of Gaza: Blog">
     <meta name="twitter:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
@@ -316,7 +316,7 @@
         const container = document.getElementById('app-container');
         const SITE_TITLE = "Echoes of Gaza: Blog";
         const SITE_DESCRIPTION = "Analysis, commentary, and updates from the archival team and invited scholars.";
-        const SITE_URL = "https://echoesofgaza.org/blog_king_response.html";
+        const SITE_URL = "https://echoesofgaza.org/blog";
         const SITE_FAVICON = "https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png";
 
         function removeMeta(selector) {
@@ -383,7 +383,7 @@
         }
 
         function getPostUrl(post) {
-            return `https://echoesofgaza.org/blog_king_response.html?post=${encodeURIComponent(post.slug || post.id)}`;
+            return `https://echoesofgaza.org/blog?post=${encodeURIComponent(post.slug || post.id)}`;
         }
 
         function sharePost(event, id) {


### PR DESCRIPTION
### Motivation
- Consolidate the blog URL to the canonical `/blog` path by replacing legacy `blog_king_response.html` references to avoid inconsistent links and share URLs.

### Description
- Replaced occurrences of `https://echoesofgaza.org/blog_king_response.html` with `https://echoesofgaza.org/blog` in `blog_king_response.html`.
- Updated the Open Graph `og:url` meta tag to the new canonical URL.
- Updated the `SITE_URL` constant and the `getPostUrl` function to generate post links under `/blog?post=...`.

### Testing
- Ran `rg -n "https://echoesofgaza.org/blog_king_response.html|blog_king_response|echoesofgaza.org/blog" .` to locate affected occurrences and confirmed replacements were targeted correctly.
- Executed a Python replace script which reported `replaced 3`, indicating three substitutions were applied successfully.
- Inspected the file diff for `blog_king_response.html` to confirm only the intended URL changes were made and no other content was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d959bf53208329ae900d07a898bb83)