### PR TITLE
Add post-specific OG/Twitter metadata for Alexandra article URL

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -3,17 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Echoes of Gaza: Blog</title>
-    <meta name="description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <title>Incident at Beth Jacob: My Response</title>
+    <meta name="description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
     <link rel="icon" href="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="Echoes of Gaza">
-    <meta property="og:title" content="Echoes of Gaza: Blog">
-    <meta property="og:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
-    <meta property="og:url" content="https://echoesofgaza.org/blog">
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="Echoes of Gaza: Blog">
-    <meta name="twitter:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta property="og:title" content="Incident at Beth Jacob: My Response">
+    <meta property="og:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
+    <meta property="og:url" content="https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response">
+    <meta property="og:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
+    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
+    <meta property="og:image:alt" content="Alexandria at the Jewish Cultural Festival in Dayton">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Incident at Beth Jacob: My Response">
+    <meta name="twitter:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
     
     <!-- Typography Imports -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -359,8 +363,12 @@
             upsertMeta('meta[property="og:description"]', { property: "og:description", content: pageDescription });
             if (pageImage) {
                 upsertMeta('meta[property="og:image"]', { property: "og:image", content: pageImage });
+                upsertMeta('meta[property="og:image:secure_url"]', { property: "og:image:secure_url", content: pageImage });
+                upsertMeta('meta[property="og:image:alt"]', { property: "og:image:alt", content: `${pageTitle} thumbnail` });
             } else {
                 removeMeta('meta[property="og:image"]');
+                removeMeta('meta[property="og:image:secure_url"]');
+                removeMeta('meta[property="og:image:alt"]');
             }
             upsertMeta('meta[property="og:url"]', { property: "og:url", content: pageUrl });
             upsertMeta('meta[name="twitter:card"]', { name: "twitter:card", content: pageImage ? "summary_large_image" : "summary" });


### PR DESCRIPTION
### Motivation
- Ensure that the specific article URL `https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response` provides the intended title, description, and thumbnail when shared on X, Facebook, and Messenger.
- Improve preview consistency across platforms by adding explicit image-related Open Graph and Twitter metadata alongside the site-level defaults.

### Description
- Updated the document head in `blog.html` to use the Alexandra article title, description, canonical post URL, and image (`og:image`, `og:image:secure_url`, `og:image:alt`, and `twitter:image`) so crawlers receive the correct preview for the specific post.
- Added `og:image:secure_url` and `og:image:alt` to the server-rendered meta tags for richer platform compatibility.
- Extended the runtime SEO updater (`setSeoMeta`) to also create and remove `og:image:secure_url` and `og:image:alt` when switching between index and article views.
- Left existing dynamic behavior intact so in-app navigation still updates title, description, URL, and image meta tags.

### Testing
- Inspected the generated diff for `blog.html` to confirm the new head meta tags and image URLs were added, and this inspection succeeded.
- Reviewed the updated `setSeoMeta` function to confirm it now upserts/removes `og:image:secure_url` and `og:image:alt` alongside existing tags, and this review succeeded.
- No automated unit tests exist for SEO meta behavior in the repository; no test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d962f54bc483299c5a043ef7498551)