### PR TITLE
Restore blog default metadata; apply Alexandra OG/Twitter only for matching post slug

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -3,21 +3,55 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Incident at Beth Jacob: My Response</title>
-    <meta name="description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
+    <title>Echoes of Gaza: Blog</title>
+    <meta name="description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
     <link rel="icon" href="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" type="image/png">
-    <meta property="og:type" content="article">
+    <meta property="og:type" content="website">
     <meta property="og:site_name" content="Echoes of Gaza">
-    <meta property="og:title" content="Incident at Beth Jacob: My Response">
-    <meta property="og:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
-    <meta property="og:url" content="https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response">
-    <meta property="og:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
-    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
-    <meta property="og:image:alt" content="Alexandria at the Jewish Cultural Festival in Dayton">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Incident at Beth Jacob: My Response">
-    <meta name="twitter:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
-    <meta name="twitter:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
+    <meta property="og:title" content="Echoes of Gaza: Blog">
+    <meta property="og:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta property="og:url" content="https://echoesofgaza.org/blog">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Echoes of Gaza: Blog">
+    <meta name="twitter:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <script>
+        (function applyPostSpecificHeadMetadata() {
+            const postSlug = new URLSearchParams(window.location.search).get("post");
+            if (postSlug !== "incident-at-beth-jacob-my-response") return;
+
+            const metadata = {
+                title: "Incident at Beth Jacob: My Response",
+                description: "I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.",
+                url: "https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response",
+                image: "https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png",
+                imageAlt: "Alexandria at the Jewish Cultural Festival in Dayton"
+            };
+
+            document.title = metadata.title;
+
+            const upsertMeta = (selector, attributes) => {
+                let tag = document.head.querySelector(selector);
+                if (!tag) {
+                    tag = document.createElement("meta");
+                    document.head.appendChild(tag);
+                }
+                Object.entries(attributes).forEach(([key, value]) => tag.setAttribute(key, value));
+            };
+
+            upsertMeta('meta[name="description"]', { name: "description", content: metadata.description });
+            upsertMeta('meta[property="og:type"]', { property: "og:type", content: "article" });
+            upsertMeta('meta[property="og:title"]', { property: "og:title", content: metadata.title });
+            upsertMeta('meta[property="og:description"]', { property: "og:description", content: metadata.description });
+            upsertMeta('meta[property="og:url"]', { property: "og:url", content: metadata.url });
+            upsertMeta('meta[property="og:image"]', { property: "og:image", content: metadata.image });
+            upsertMeta('meta[property="og:image:secure_url"]', { property: "og:image:secure_url", content: metadata.image });
+            upsertMeta('meta[property="og:image:alt"]', { property: "og:image:alt", content: metadata.imageAlt });
+            upsertMeta('meta[name="twitter:card"]', { name: "twitter:card", content: "summary_large_image" });
+            upsertMeta('meta[name="twitter:title"]', { name: "twitter:title", content: metadata.title });
+            upsertMeta('meta[name="twitter:description"]', { name: "twitter:description", content: metadata.description });
+            upsertMeta('meta[name="twitter:image"]', { name: "twitter:image", content: metadata.image });
+        })();
+    </script>
     
     <!-- Typography Imports -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
### Motivation
- Prevent the blog index from inheriting Alexandra’s article metadata by reverting head tags to generic /blog values so the home URL does not surface a single post’s title/image/description.
- Ensure Alexandra’s OG/Twitter/title/description/image metadata are only exposed when the exact post URL is requested, preserving correct social previews for the single post.

### Description
- Replaced the static post-specific `<head>` values in `blog.html` with generic blog defaults (title, description, `og:type` set to `website`, `og:title`, `og:description`, `og:url` and Twitter tags pointing to the blog home).
- Added an early-executing self-invoking script in the `<head>` that reads `?post=` via `new URLSearchParams(window.location.search).get("post")` and only upserts the Alexandra article metadata when the slug equals `incident-at-beth-jacob-my-response`.
- The injected post metadata includes `title`, `description`, `og:url` fixed to `https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response`, `og:image`/`og:image:secure_url`/`og:image:alt`, and corresponding Twitter tags.
- Implemented a small `upsertMeta` helper within the script to create or update meta tags reliably.

### Testing
- Inspected the file head with `sed -n '1,260p' blog.html` and confirmed the top-level defaults are now generic, which succeeded.
- Searched for existing OG/Twitter/meta occurrences with `rg -n "og:|twitter:|document.title|meta" blog.html` and verified the targeted script and tag updates, which succeeded.
- Viewed the numbered file to confirm script placement using `nl -ba blog.html | sed -n '1,120p'`, which succeeded.
- Applied the patch via the repository tooling (`apply_patch`) and the tool reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a81c4a0c832985d780e31b440a43)