### PR TITLE
Dynamically adjust blog page head metadata based on `post` query param

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -18,6 +18,79 @@
     <meta name="twitter:title" content="Incident at Beth Jacob: My Response">
     <meta name="twitter:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png">
+    <script>
+        (function applyPostSpecificHeadMetadata() {
+            const postSlug = new URLSearchParams(window.location.search).get("post");
+            if (postSlug !== "incident-at-beth-jacob-my-response") {
+                const removeMeta = (selector) => {
+                    const tag = document.head.querySelector(selector);
+                    if (tag) tag.remove();
+                };
+
+                const upsertMeta = (selector, attributes) => {
+                    let tag = document.head.querySelector(selector);
+                    if (!tag) {
+                        tag = document.createElement("meta");
+                        document.head.appendChild(tag);
+                    }
+                    Object.entries(attributes).forEach(([key, value]) => tag.setAttribute(key, value));
+                };
+
+                const generic = {
+                    title: "Echoes of Gaza: Blog",
+                    description: "Analysis, commentary, and updates from the archival team and invited scholars.",
+                    url: "https://echoesofgaza.org/blog"
+                };
+
+                document.title = generic.title;
+                upsertMeta('meta[name="description"]', { name: "description", content: generic.description });
+                upsertMeta('meta[property="og:type"]', { property: "og:type", content: "website" });
+                upsertMeta('meta[property="og:title"]', { property: "og:title", content: generic.title });
+                upsertMeta('meta[property="og:description"]', { property: "og:description", content: generic.description });
+                upsertMeta('meta[property="og:url"]', { property: "og:url", content: generic.url });
+                upsertMeta('meta[name="twitter:card"]', { name: "twitter:card", content: "summary" });
+                upsertMeta('meta[name="twitter:title"]', { name: "twitter:title", content: generic.title });
+                upsertMeta('meta[name="twitter:description"]', { name: "twitter:description", content: generic.description });
+                removeMeta('meta[property="og:image"]');
+                removeMeta('meta[property="og:image:secure_url"]');
+                removeMeta('meta[property="og:image:alt"]');
+                removeMeta('meta[name="twitter:image"]');
+                return;
+            }
+
+            const metadata = {
+                title: "Incident at Beth Jacob: My Response",
+                description: "I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.",
+                url: "https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response",
+                image: "https://raw.githubusercontent.com/rscboy/eyes-on-palestine/refs/heads/main/alexandria_blog_image.png",
+                imageAlt: "Alexandria at the Jewish Cultural Festival in Dayton"
+            };
+
+            document.title = metadata.title;
+
+            const upsertMeta = (selector, attributes) => {
+                let tag = document.head.querySelector(selector);
+                if (!tag) {
+                    tag = document.createElement("meta");
+                    document.head.appendChild(tag);
+                }
+                Object.entries(attributes).forEach(([key, value]) => tag.setAttribute(key, value));
+            };
+
+            upsertMeta('meta[name="description"]', { name: "description", content: metadata.description });
+            upsertMeta('meta[property="og:type"]', { property: "og:type", content: "article" });
+            upsertMeta('meta[property="og:title"]', { property: "og:title", content: metadata.title });
+            upsertMeta('meta[property="og:description"]', { property: "og:description", content: metadata.description });
+            upsertMeta('meta[property="og:url"]', { property: "og:url", content: metadata.url });
+            upsertMeta('meta[property="og:image"]', { property: "og:image", content: metadata.image });
+            upsertMeta('meta[property="og:image:secure_url"]', { property: "og:image:secure_url", content: metadata.image });
+            upsertMeta('meta[property="og:image:alt"]', { property: "og:image:alt", content: metadata.imageAlt });
+            upsertMeta('meta[name="twitter:card"]', { name: "twitter:card", content: "summary_large_image" });
+            upsertMeta('meta[name="twitter:title"]', { name: "twitter:title", content: metadata.title });
+            upsertMeta('meta[name="twitter:description"]', { name: "twitter:description", content: metadata.description });
+            upsertMeta('meta[name="twitter:image"]', { name: "twitter:image", content: metadata.image });
+        })();
+    </script>
     
     <!-- Typography Imports -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
### Motivation
- Ensure correct page title and social/SEO metadata when the blog is viewed as the generic listing versus a specific post by detecting the `post` query parameter.
- Prevent inappropriate or missing social preview images for the generic blog listing by removing post-specific image meta when not viewing the post.
- Centralize and control head meta updates client-side so the single `blog.html` can serve both the listing and individual post presentation.

### Description
- Added an inline script that runs `applyPostSpecificHeadMetadata()` on load and reads `new URLSearchParams(window.location.search).get("post")` to determine mode.
- Implemented `upsertMeta` and `removeMeta` helpers to create/update or remove meta tags in the document head and to set `document.title` appropriately for either the generic blog or the specific post.
- For the generic listing it sets a site-wide title/description/URL and removes post image meta (`og:image`, `og:image:secure_url`, `og:image:alt`, `twitter:image`), and for the post it upserts article-specific `og` and `twitter` tags including `og:image` and `twitter:image`.
- Left existing typography and tailwind configuration intact and scoped the changes to head metadata manipulation only.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a81c4a0c832985d780e31b440a43)