### PR TITLE
Move Beth Jacob post to dedicated page and update blog index links

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -3,29 +3,29 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Incident at Beth Jacob: My Response</title>
-    <meta name="description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
+    <title>Echoes of Gaza: Blog</title>
+    <meta name="description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
     <link rel="icon" href="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" type="image/png">
-    <meta property="og:type" content="article">
+    <meta property="og:type" content="website">
     <meta property="og:site_name" content="Echoes of Gaza">
-    <meta property="og:title" content="Incident at Beth Jacob: My Response">
-    <meta property="og:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
-    <meta property="og:url" content="https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response">
+    <meta property="og:title" content="Echoes of Gaza: Blog">
+    <meta property="og:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta property="og:url" content="https://echoesofgaza.org/blog">
     <meta property="og:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png">
     <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png">
     <meta property="og:image:alt" content="Alexandria at the Jewish Cultural Festival in Dayton">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Incident at Beth Jacob: My Response">
-    <meta name="twitter:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Echoes of Gaza: Blog">
+    <meta name="twitter:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png">
     <script>
         (function applyPostSpecificHeadMetadata() {
             const postSlug = new URLSearchParams(window.location.search).get("post");
-            const metadata = postSlug === "incident-at-beth-jacob-my-response"
+            const metadata = ["incident-at-beth-jacob-my-response", "incident-at-beth-jacob"].includes(postSlug)
                 ? {
                     title: "Incident at Beth Jacob: My Response",
                     description: "I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.",
-                    url: "https://echoesofgaza.org/blog?post=incident-at-beth-jacob-my-response",
+                    url: "https://echoesofgaza.org/blog/incident-at-beth-jacob.html",
                     image: "https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png",
                     imageAlt: "Alexandria at the Jewish Cultural Festival in Dayton",
                     twitterCard: "summary_large_image",
@@ -342,7 +342,8 @@
         const posts = [
             {
                 id: 1,
-                slug: "incident-at-beth-jacob-my-response",
+                slug: "incident-at-beth-jacob",
+                path: "incident-at-beth-jacob.html",
                 title: "Incident at Beth Jacob: My Response",
                 subtitle: "I have had over a month to mull this situation over in my head. I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.",
                 shareDescription: "I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.",
@@ -451,6 +452,7 @@
         }
 
         function getPostUrl(post) {
+            if (post.path) return `https://echoesofgaza.org/blog/${post.path}`;
             return `https://echoesofgaza.org/blog?post=${encodeURIComponent(post.slug || post.id)}`;
         }
 
@@ -518,8 +520,10 @@
             `;
 
             posts.forEach(post => {
+                const postUrl = getPostUrl(post);
                 html += `
-                    <article class="group cursor-pointer" onclick="renderPost(${post.id}, true)">
+                    <article class="group">
+                        <a href="${postUrl}" class="block cursor-pointer">
                         <!-- Meta -->
                         <div class="flex items-center gap-2 mb-2 text-sm text-ash-gray font-sans">
                             <span class="font-medium text-off-white">${post.author}</span>
@@ -531,6 +535,7 @@
                         <h2 class="text-[24px] font-serif font-bold text-off-white leading-tight mb-2 group-hover:text-ash-gray transition-colors">${post.title}</h2>
                         <p class="text-ash-gray text-[16px] leading-snug mb-4 font-sans line-clamp-2">${post.subtitle}</p>
                         
+                        </a>
                         <!-- Action Row -->
                         <div class="flex items-center gap-6 mt-4 border-t border-border-gray pt-4 opacity-70 group-hover:opacity-100 transition-opacity">
                             <div class="action-btn" title="View Citations">
@@ -701,7 +706,7 @@
             );
 
             if (post) {
-                renderPost(post.id, false);
+                window.location.replace(getPostUrl(post));
             } else {
                 renderIndex();
             }

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -1,1 +1,50 @@
-insert here
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Incident at Beth Jacob: My Response</title>
+  <meta name="description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something." />
+  <link rel="canonical" href="https://echoesofgaza.org/blog/incident-at-beth-jacob.html" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="Echoes of Gaza" />
+  <meta property="og:title" content="Incident at Beth Jacob: My Response" />
+  <meta property="og:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something." />
+  <meta property="og:url" content="https://echoesofgaza.org/blog/incident-at-beth-jacob.html" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png" />
+  <meta property="og:image:alt" content="Alexandria at the Jewish Cultural Festival in Dayton" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Incident at Beth Jacob: My Response" />
+  <meta name="twitter:description" content="I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-[#0B0B0B] text-[#EDEDED] antialiased">
+  <main class="max-w-[680px] mx-auto px-5 py-10">
+    <a href="https://echoesofgaza.org/blog" class="text-[#8C0D0D] text-sm font-bold uppercase tracking-widest hover:text-white">&larr; Blog Index</a>
+
+    <header class="mt-6 mb-8">
+      <h1 class="text-[40px] md:text-[48px] leading-tight font-bold mb-4">Incident at Beth Jacob: My Response</h1>
+      <h2 class="text-[20px] md:text-[22px] text-[#7A7A7A] mb-8">I have had over a month to mull this situation over in my head. I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something.</h2>
+      <div class="py-5 border-y border-[#2A2A2A] text-sm text-[#7A7A7A]">
+        <span class="text-[#EDEDED] font-medium">Alexandria Gary King / נחמה בת אברהם ושרה</span>
+        <span> • 3/31/2026 / י&quot;ג בניסן תשפ&quot;ו • 4 min read</span>
+      </div>
+    </header>
+
+    <article class="space-y-6 text-[19px] leading-relaxed">
+      <p><strong>Note:</strong> I will not be discussing anything outside of the scope of what I have witnessed firsthand. I know that this topic has had some impact outside of what I have been able to see personally, but I have no intention of speculating on events that are outside of my purview.</p>
+      <p>I have had over a month to mull this situation over in my head. I have been dealing with a lot of complicated thoughts and emotions when it comes to this topic, but I feel that if I’m going to experience any kind of closure from this, I need to say something. This is not a piece defending myself or an attempt to attack anyone. If it were up to me, this never would have happened, and I would have continued as things were, but unfortunately that is impossible. I’m sure that many people reading this have no idea what I’m talking about, so I’ll lay down some background, explain what happened, and attempt to clarify some points. Through this, I hope to lay a better path forward not only for myself, but also hopefully for the greater Jewish community.</p>
+      <figure class="float-right w-48 md:w-56 ml-6 mb-4 mt-2">
+        <img src="https://raw.githubusercontent.com/rscboy/eyes-on-palestine/main/alexandria_blog_image.png" alt="Alexandria at the Jewish Cultural Festival in Dayton" class="w-full rounded-sm object-cover border border-[#2A2A2A]" />
+        <figcaption class="text-[11px] text-[#7A7A7A] mt-2 leading-tight text-right italic">Alexandria at the Jewish Cultural Festival in Dayton</figcaption>
+      </figure>
+      <p>First, for those who don’t know who I am, I am Alexandria King (Hebrew Name: נחמה בת אברהם ושרה) and I am a twenty-nine-year-old college student in Dayton, Ohio, direct support professional, and a proud Jew by choice. I am a member of Temple Israel (a reform synagogue in Dayton) and had been attending services at Beth Jacob Synagogue (an Orthodox synagogue) off and on for some time. The appeal of attending Beth Jacob services despite the fact that I am not the most frum (observant) person was that I found great comfort in the ritual of the Orthodox service. I enjoyed coming in early, going through the liturgy, and hearing the entire Torah and Haftorah portions. Most importantly, I always looked forward to Rabbi Agar’s drashes (sermons). I was always interested to see where he was going to take the portion and what stories he was going to tell; however, services didn’t always go smoothly. I can recall on at least one occasion where service was interrupted by someone going into the hallway and throwing a fit (this is what those in the storytelling business call foreshadowing.)</p>
+      <p>It was the 28th of February when, as was normal for me at this point, I went to services at Beth Jacob. Nothing was out of the ordinary, me and my partner Isaac were worshiping on separate sides of the מחיצה (mechitza, a divider at an Orthodox Synagogue to split men and women) when suddenly there was a commotion in the hallway. There was a woman who was terribly upset about someone being allowed at the synagogue. It was hard to make it out, but they were yelling phrases such as “sin against god,” “they’re not a member,” “anti-Israel,” “pro-Pali,” and “it’s them or me.” There was a point in that diatribe in which I was pretty certain that this person was referring to me, and when I looked back to see Leibel (Rabbi Agar) gesturing me to come back, my suspicions were confirmed. He asked me to leave. I was willing, albeit with consternation, quietly and without fuss. That is until the woman, as I was leaving, decided that she wanted to put salt on the wound and say things to my face. I was already in fight or flight mode, a feeling that was remarkably familiar to me and was reminiscent of times I have been physically attacked, and decided to tell her, in some impolite words, to get out of my face. From there I left and began to have an emotional breakdown in my car. The next week, I was contacted by a detective from the Sheriff’s office that I was asked to not return to the synagogue because of MY disturbance and rude language (and specifically not because of my views or where I was sitting, according to them.)</p>
+      <p>I have had a lot of feelings about this situation, but the main one is one of deep hurt. I felt like I was being abandoned by someone I once considered a friend and a trusted community leader. I felt like I was no longer safe in my Jewish Community because of who I am. A woman who I have never met before comes in and yells about me, and I’m the one who must leave? It makes no sense to me, and it feels like they were looking for an excuse not to have me come, and this just fell into their laps. I can’t honestly think of any other explanation than either malice or incompetence, and I’d believe either one at this point.</p>
+      <p>Now, I want to make one thing explicit: yes, I am and have always been staunchly for the self-determination of the Palestinian people. I believe that Israel’s actions on that front have been and continue to be abhorrent. At the same time, I believe deeply in the safety, dignity, and self-determination of Jewish people. I do not at all believe that these commitments are contradictory. I am a person who believes that if we want something to be better, we must be able to criticize it. The Torah calls for us to be a holy nation and to pursue justice justly, and I do not believe that the state of Israel holds itself to that standard. I will continue to work toward betterment; however, that does not make me an antisemite or worthy of being excluded from Jewish spaces.</p>
+      <p>To conclude, I just want to say that I am not sure what will come out of this. I know that there have already been discussions about what happened on that day to which I am not privy. Despite my efforts to keep this in my small circle of disclosure, I should’ve known that it was going to get out regardless of who I spoke to. I just want to say that even though I am hurt still, this is not something that happens in all Jewish Spaces. There have been countless spaces that my Queer Pro-Palestinian Jewish self has felt wholly welcome in. This is more so a cautionary tale that not all Jewish spaces are safe, and that not all leadership can lead.</p>
+    </article>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a clean, dedicated URL for the Beth Jacob post (`/blog/incident-at-beth-jacob.html`) while keeping the blog index fast and smooth when opening the article in the same tab.
- Preserve backwards compatibility so legacy query URLs like `?post=incident-at-beth-jacob-my-response` continue to work by redirecting to the new page.

### Description
- Added a standalone article file at `blog/incident-at-beth-jacob.html` containing canonical, OG, and Twitter metadata plus the full article body content.
- Updated `blog.html` to treat the index as the site-level page (adjusted title/description/OG/twitter metadata) and to map the post to a `path` (`incident-at-beth-jacob.html`) in the `posts` array.
- Changed post URL generation (`getPostUrl`) and share logic to prefer `post.path` so links and clipboard shares point to `/blog/incident-at-beth-jacob.html`.
- Replaced the index card click behavior with a normal same-tab anchor (`<a href=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6f8bba788329af8fc36778338f6e)