### PR TITLE
Remove newsletter subscribe sections from blog pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -267,14 +267,6 @@
                 </p>
             </div>
             
-            <div class="flex items-center gap-4 w-full md:w-auto">
-                <form class="flex w-full md:w-auto" onsubmit="event.preventDefault();">
-                    <input type="email" placeholder="Email Address" class="bg-[#111] border border-border-gray border-r-0 text-off-white px-4 py-3 w-full md:w-64 text-sm focus:outline-none focus:border-deep-red transition-colors placeholder-ash-gray">
-                    <button class="bg-deep-red text-off-white px-6 py-3 text-sm font-medium hover:bg-red-900 transition-colors uppercase tracking-wider whitespace-nowrap">
-                        Subscribe
-                    </button>
-                </form>
-            </div>
         </div>
     </section>
 
@@ -666,17 +658,6 @@
                             </div>
                              <div class="action-btn ml-auto" onclick="sharePost(event, ${post.id})" title="Copy Link">
                                 <i class="ph ph-share-network text-xl"></i>
-                            </div>
-                        </div>
-
-                        <!-- Subscribe Box -->
-                        <div class="bg-[#111] border border-border-gray p-8 text-center rounded-sm my-8">
-                            <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-12 w-auto mx-auto mb-4 object-contain">
-                            <h3 class="text-off-white font-serif text-xl font-bold mb-2">Echoes of Gaza: Blog</h3>
-                            <p class="text-ash-gray text-sm mb-6 max-w-sm mx-auto">Get weekly analysis from Prof. Miller and invited guests directly to your inbox.</p>
-                            <div class="flex gap-2 max-w-sm mx-auto">
-                                <input type="email" placeholder="Email address" class="bg-black border border-border-gray text-white px-3 py-2 w-full text-sm focus:border-deep-red outline-none">
-                                <button class="bg-deep-red text-white px-4 py-2 text-sm font-medium whitespace-nowrap hover:bg-red-900 transition-colors">Subscribe</button>
                             </div>
                         </div>
 

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -209,14 +209,6 @@
                 </p>
             </div>
 
-            <div class="flex items-center gap-4 w-full md:w-auto">
-                <form class="flex w-full md:w-auto" onsubmit="event.preventDefault();">
-                    <input type="email" placeholder="Email Address" class="bg-[#111] border border-border-gray border-r-0 text-off-white px-4 py-3 w-full md:w-64 text-sm focus:outline-none focus:border-deep-red transition-colors placeholder-ash-gray">
-                    <button class="bg-deep-red text-off-white px-6 py-3 text-sm font-medium hover:bg-red-900 transition-colors uppercase tracking-wider whitespace-nowrap">
-                        Subscribe
-                    </button>
-                </form>
-            </div>
         </div>
     </section>
 
@@ -608,17 +600,6 @@
                             </div>
                              <div class="action-btn ml-auto" onclick="sharePost(event, ${post.id})" title="Copy Link">
                                 <i class="ph ph-share-network text-xl"></i>
-                            </div>
-                        </div>
-
-                        <!-- Subscribe Box -->
-                        <div class="bg-[#111] border border-border-gray p-8 text-center rounded-sm my-8">
-                            <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-12 w-auto mx-auto mb-4 object-contain">
-                            <h3 class="text-off-white font-serif text-xl font-bold mb-2">Echoes of Gaza: Blog</h3>
-                            <p class="text-ash-gray text-sm mb-6 max-w-sm mx-auto">Get weekly analysis from Prof. Miller and invited guests directly to your inbox.</p>
-                            <div class="flex gap-2 max-w-sm mx-auto">
-                                <input type="email" placeholder="Email address" class="bg-black border border-border-gray text-white px-3 py-2 w-full text-sm focus:border-deep-red outline-none">
-                                <button class="bg-deep-red text-white px-4 py-2 text-sm font-medium whitespace-nowrap hover:bg-red-900 transition-colors">Subscribe</button>
                             </div>
                         </div>
 


### PR DESCRIPTION
### Motivation
- The site should no longer present newsletter signup prompts on blog pages to remove subscription UI elements.
- This change targets both the blog index and individual post pages where subscribe controls duplicated the site’s engagement flow.

### Description
- Removed the masthead newsletter signup form from `blog.html` so the hero only displays branding and descriptive text.
- Removed the in-post “Subscribe Box” callout from `blog.html` so the engagement area flows directly into the comments preview.
- Applied the same two removals to the dedicated post page `blog/incident-at-beth-jacob.html` to keep pages consistent.
- No other layout or post rendering logic was changed; only the HTML blocks for the subscription input/buttons were deleted.

### Testing
- Ran `rg -n "Subscribe|subscribe|newsletter|Email Address|Email address" blog.html blog/incident-at-beth-jacob.html` to verify no newsletter subscription UI text remains, and the search returned no matches (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd11cf5174832983f58f24dd965473)