### PR TITLE
Move social stats below article and remove comments UI

### DIFF
--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -187,7 +187,7 @@
             display: flex;
             align-items: center;
             gap: 16px;
-            margin-bottom: 20px;
+            margin-top: 20px;
             padding: 12px 0;
             border-top: 1px solid #2A2A2A;
             border-bottom: 1px solid #2A2A2A;
@@ -613,25 +613,25 @@
                         </div>
                     </header>
 
-	                    <div class="social-stats">
-	                        <button id="likeBtn" class="stat-btn" aria-label="Like this page">
-	                            <span>♥</span>
-	                            <span id="likeCount">0</span>
-	                        </button>
-	                        <span class="stat-item" aria-label="Views">
-	                            <span>👁</span>
-	                            <span id="viewCount">0</span>
-	                        </span>
-	                        <button id="shareBtn" class="stat-btn" aria-label="Share this page">
-	                            <span>↗</span>
-	                            <span id="shareCount">0</span>
-	                        </button>
-	                    </div>
-
 	                    <!-- Body -->
 	                    <article class="prose-content">
 	                        ${post.content}
 	                    </article>
+
+	                    <div class="social-stats">
+	                        <button id="likeBtn" class="stat-btn" aria-label="Like this page">
+	                            <i class="ph ph-heart"></i>
+	                            <span id="likeCount">0</span>
+	                        </button>
+	                        <span class="stat-item" aria-label="Views">
+	                            <i class="ph ph-eye"></i>
+	                            <span id="viewCount">0</span>
+	                        </span>
+	                        <button id="shareBtn" class="stat-btn" aria-label="Share this page">
+	                            <i class="ph ph-share-network"></i>
+	                            <span id="shareCount">0</span>
+	                        </button>
+	                    </div>
 
                     <!-- Editor's Note -->
                     <section class="mt-8 p-4 border border-border-gray bg-[#111] rounded-sm">
@@ -651,19 +651,9 @@
                                 <i class="ph ph-seal-check text-xl"></i>
                                 <span class="text-sm">${post.citations} Citations</span>
                             </div>
-                            <div class="action-btn" title="View Comments">
-                                <i class="ph ph-chat-circle text-xl"></i>
-                                <span class="text-sm">${post.comments} Responses</span>
-                            </div>
                              <div class="action-btn ml-auto" onclick="sharePost(event, ${post.id})" title="Copy Link">
                                 <i class="ph ph-share-network text-xl"></i>
                             </div>
-                        </div>
-
-                        <!-- Comments Section (Preview) -->
-                        <div class="bg-black py-4">
-                            <h3 class="font-sans font-bold text-sm uppercase tracking-widest text-off-white mb-6">Responses (${post.comments})</h3>
-                             <button class="text-deep-red text-sm font-medium hover:underline">Write a response...</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Keep the article page layout cleaner by moving the social stats bar beneath the article body and remove the site comments UI for this post.
- Remove emoji glyphs in favor of consistent Phosphor iconography for accessibility and visual consistency.

### Description
- Moved the `.social-stats` HTML block so it renders directly under the article body in `renderPost` inside `blog/incident-at-beth-jacob.html`.
- Replaced emoji symbols (`♥`, `👁`, `↗`) with Phosphor icons (`ph-heart`, `ph-eye`, `ph-share-network`) in the social controls.
- Removed the comments preview block and removed the comments action from the engagement row on the article view in `blog/incident-at-beth-jacob.html`.
- Adjusted the `.social-stats` CSS spacing from `margin-bottom: 20px` to `margin-top: 20px` so the bar sits cleanly under the article content.

### Testing
- Searched the updated file for removed emoji and comment strings with `rg` and confirmed there were no matches for `♥|👁|↗|Write a response|Responses (${post.comments})` (no matches).
- Reviewed the changes with `git diff -- blog/incident-at-beth-jacob.html` to confirm the HTML/CSS edits and relocation of the stats block.
- Committed the change (`git commit`) after verification; the commit succeeded and the diff shows the intended insertions and deletions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd231a53b48329bde048f6ebc47eea)