### PR TITLE
Fix Blog Home link and update Blog description copy

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -255,7 +255,7 @@
                     <a href="https://echoesofgaza.org">
                         <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-10 w-auto object-contain hover:opacity-80 transition-opacity">
                     </a>
-                    <a href="#" onclick="renderIndex(); return false;" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
+                    <a href="https://echoesofgaza.org/blog/" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
                         Blog Home
                     </a>
                 </div>
@@ -560,7 +560,7 @@
                             <div>
                                 <h3 class="text-off-white font-sans font-bold text-sm tracking-widest uppercase mb-4">About the Blog</h3>
                                 <p class="text-ash-gray text-sm leading-relaxed mb-4">
-                                    The Blog serves as the collaborative layer of the Archive. Here, community members, activists, local voices, academics, and scholars provide weekly commentary on the documentation process.
+                                    The Blog is the narrative layer of the Archive. While Echoes of Gaza documents the historical record, this space centers the lived experiences behind it. Here, community members, activists, academics, and local voices share personal stories, reflections, and testimonies that reveal the emotional weight, trauma, and real-world consequences of speaking out for Palestine. These stories transform documentation into human experience, ensuring that what is recorded is also felt.
                                 </p>
                             </div>
 

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -234,7 +234,7 @@
                     <a href="https://echoesofgaza.org">
                         <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-10 w-auto object-contain hover:opacity-80 transition-opacity">
                     </a>
-                    <a href="#" onclick="renderIndex(); return false;" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
+                    <a href="https://echoesofgaza.org/blog/" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
                         Blog Home
                     </a>
                 </div>
@@ -541,7 +541,7 @@
                             <div>
                                 <h3 class="text-off-white font-sans font-bold text-sm tracking-widest uppercase mb-4">About the Blog</h3>
                                 <p class="text-ash-gray text-sm leading-relaxed mb-4">
-                                    The Blog serves as the collaborative layer of the Archive. Here, community members, activists, local voices, academics, and scholars provide weekly commentary on the documentation process.
+                                    The Blog is the narrative layer of the Archive. While Echoes of Gaza documents the historical record, this space centers the lived experiences behind it. Here, community members, activists, academics, and local voices share personal stories, reflections, and testimonies that reveal the emotional weight, trauma, and real-world consequences of speaking out for Palestine. These stories transform documentation into human experience, ensuring that what is recorded is also felt.
                                 </p>
                             </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the Blog masthead navigates users back to the blog root URL and refresh the sidebar copy to better reflect the site’s narrative framing of the archive.

### Description
- Replaced the `Blog Home` masthead anchor to point to `https://echoesofgaza.org/blog/` in `blog.html` and `blog/incident-at-beth-jacob.html`.
- Replaced the sidebar “About the Blog” paragraph in both files with the new narrative-focused copy.
- Changes applied to `blog.html` and `blog/incident-at-beth-jacob.html` and staged/committed.

### Testing
- Verified the updated link and paragraph text with `rg -n "Blog Home|The Blog is the narrative layer" blog.html blog/incident-at-beth-jacob.html` which returned the new entries (success).
- Confirmed modified files with `git status --short` which showed `blog.html` and `blog/incident-at-beth-jacob.html` as modified (success).
- Committed the changes with `git commit` which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd24bb47908329a44886329def20e8)