### PR TITLE
Fix Blog Home links to canonical /blog URL

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -255,7 +255,7 @@
                     <a href="https://echoesofgaza.org">
                         <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-10 w-auto object-contain hover:opacity-80 transition-opacity">
                     </a>
-                    <a href="https://echoesofgaza.org/blog/" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
+                    <a href="https://echoesofgaza.org/blog" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
                         Blog Home
                     </a>
                 </div>

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -234,7 +234,7 @@
                     <a href="https://echoesofgaza.org">
                         <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Logo" class="h-10 w-auto object-contain hover:opacity-80 transition-opacity">
                     </a>
-                    <a href="https://echoesofgaza.org/blog/" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
+                    <a href="https://echoesofgaza.org/blog" class="text-xs font-sans text-deep-red font-bold uppercase tracking-widest hover:text-off-white transition-colors">
                         Blog Home
                     </a>
                 </div>


### PR DESCRIPTION
### Motivation
- Ensure the Blog Home masthead link uses the canonical URL `https://echoesofgaza.org/blog` (no trailing slash) to avoid URL inconsistencies.

### Description
- Replaced `href="https://echoesofgaza.org/blog/"` with `href="https://echoesofgaza.org/blog"` in `blog.html` and `blog/incident-at-beth-jacob.html`.

### Testing
- Verified the updated anchor values by running `rg -n 'Blog Home|href="https://echoesofgaza.org/blog"' blog.html blog/incident-at-beth-jacob.html` and inspecting the diffs which show the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd25f3defc83299deecfae2b49d2ef)