### PR TITLE
Add redirect page for trailing-slash /blog/ URL

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting to /blog</title>
+    <link rel="canonical" href="https://echoesofgaza.org/blog" />
+    <meta http-equiv="refresh" content="0; url=/blog" />
+    <script>
+      window.location.replace('/blog');
+    </script>
+  </head>
+  <body>
+    <p>If you are not redirected automatically, <a href="/blog">go to /blog</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Prevent users from landing on a 404 when they visit the trailing-slash URL `/blog/` by routing them to the canonical `/blog` page instead.

### Description
- Added `blog/index.html` which immediately redirects to `/blog`.
- Redirect is implemented via a `<meta http-equiv="refresh">` and a `window.location.replace('/blog')` JavaScript fallback.
- Included a `<link rel="canonical" href="https://echoesofgaza.org/blog" />` and a manual `<a href="/blog">` fallback for users with restrictive browsers.

### Testing
- Verified working tree before commit with `git status --short` which showed only the new file as untracked and then clean after commit; this succeeded.
- Committed the change with `git add blog/index.html && git commit -m "Add /blog/ fallback redirect to /blog"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2692cb3883298bd1dd0189d3c4c2)