### PR TITLE
Add EoG Blog link and temporary homepage announcement banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
                         </button>
                         <div id="resources-menu-dropdown" class="absolute left-1/2 -translate-x-1/2 top-full pt-4 w-48 hidden group-hover:block z-50">
                             <div class="bg-[#0a0a0a] border border-[#222] shadow-2xl">
+                             <a href="https://echoesofgaza.org/blog" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Blog</a>
                              <a href="https://echoesofgaza.org/podcast" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Podcast</a>
                                 <a href="#quotes" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Quotes & Resources</a>
                                 <a href="https://echoesofgaza.org/events" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Events</a>
@@ -458,6 +459,14 @@
             <a href="#faq" class="mobile-nav-link text-gray-400 hover:text-white transition">FAQ</a>
             <a href="https://echoesofgaza.org/collab" class="mobile-nav-link btn-primary px-8 py-3 rounded text-sm uppercase">Submit Evidence</a>
         </nav>
+    </div>
+
+    <div id="top-announcement-banner" class="hidden pt-[60px] bg-[#2a0a0a] border-b border-[#5c0f1c]">
+        <div class="max-w-7xl mx-auto px-6 lg:px-8 py-3 text-center">
+            <p class="text-xs md:text-sm text-[#f2e7d5] leading-relaxed">
+                New: <a href="https://echoesofgaza.org/blog" class="underline underline-offset-4 hover:text-white transition">EoG Blog</a> is live — featuring lived experiences, the real cost of speaking out for Palestine, Palestinian narratives in Dayton, and voices from academics.
+            </p>
+        </div>
     </div>
 
     <!-- MAIN CONTENT -->
@@ -781,6 +790,11 @@
             <div class="container mx-auto px-6">
                 <h3 class="text-2xl font-serif font-bold mb-16 text-center text-white/90">Resources</h3>
                 <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 text-center">
+                    <div class="card-modern p-8 flex flex-col items-center">
+                        <h4 class="font-serif font-bold text-white mb-3">EoG Blog</h4>
+                        <p class="text-gray-500 text-xs mb-6 flex-grow leading-relaxed">Read the latest Echoes of Gaza writing focused on lived experiences and firsthand narratives.</p>
+                        <a href="https://echoesofgaza.org/blog" class="mt-auto btn-dark-uniform text-xs uppercase tracking-widest py-2 px-6 rounded">Read Blog</a>
+                    </div>
                     <div class="card-modern p-8 flex flex-col items-center">
                         <h4 class="font-serif font-bold text-white mb-3">Toolkit</h4>
                         <p class="text-gray-500 text-xs mb-6 flex-grow leading-relaxed">A toolkit to help advocate for sustainable peace and accountability.</p>
@@ -12752,6 +12766,17 @@ source: "Haaretz"
             const root = ReactDOM.createRoot(rootElement);
             root.render(<StoryGenerator />);
         }
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const topAnnouncementBanner = document.getElementById('top-announcement-banner');
+            if (!topAnnouncementBanner) return;
+
+            const bannerEndDate = new Date('2026-04-27T00:00:00Z');
+            if (new Date() < bannerEndDate) {
+                topAnnouncementBanner.classList.remove('hidden');
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Surface the new Echoes of Gaza (EoG) Blog in the site navigation and Resources section and provide a short-term homepage announcement to promote the launch through April 26.

### Description
- Added an `EoG Blog` entry at the top of the desktop Resources dropdown linking to `https://echoesofgaza.org/blog` in `index.html`.
- Added an `EoG Blog` card to the homepage Resources grid linking to `https://echoesofgaza.org/blog`.
- Added a top announcement banner with the requested copy and a small client-side script that shows the banner only while the current date is before `2026-04-27T00:00:00Z` (so it is active through April 26, 2026). All changes are in `index.html`.

### Testing
- Repository file/diff inspection confirmed the new link, Resources card, and banner markup were added to `index.html` successfully.
- Script insertion was inspected to verify the banner is toggled based on the date condition and will stop showing after the configured end date.
- No unit tests were added; repository checks and content verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd27c9b488832988c00f90f4dacf1e)