### PR TITLE
Improve readability of About the Blog sidebar copy

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -560,7 +560,10 @@
                             <div>
                                 <h3 class="text-off-white font-sans font-bold text-sm tracking-widest uppercase mb-4">About the Blog</h3>
                                 <p class="text-ash-gray text-sm leading-relaxed mb-4">
-                                    The Blog is the narrative layer of the Archive. While Echoes of Gaza documents the historical record, this space centers the lived experiences behind it. Here, community members, activists, academics, and local voices share personal stories, reflections, and testimonies that reveal the emotional weight, trauma, and real-world consequences of speaking out for Palestine. These stories transform documentation into human experience, ensuring that what is recorded is also felt.
+                                    The Blog is the narrative layer of the Archive. While Echoes of Gaza documents the historical record, this space centers the lived experiences behind it.
+                                </p>
+                                <p class="text-ash-gray text-sm leading-relaxed mb-4">
+                                    Here, community members, activists, academics, and local voices share personal stories, reflections, and testimonies that reveal the emotional weight, trauma, and real-world consequences of speaking out for Palestine. These stories transform documentation into human experience, ensuring that what is recorded is also felt.
                                 </p>
                             </div>
 


### PR DESCRIPTION
### Motivation
- Make the sidebar `About the Blog` blurb easier to scan by breaking a long sentence into two shorter paragraphs starting at "Here, community members...".

### Description
- Updated `blog.html` to split the existing single `<p>` block into two `<p>` blocks so the sentence beginning with "Here, community members, activists, academics, and local voices..." starts a new paragraph.

### Testing
- No automated tests were run since this is a text-only HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd281c56c88329bd2750fbf70c4118)