### PR TITLE
Update blog intro copy on listing and incident pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Voices from Echoes of Gaza</title>
-    <meta name="description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta name="description" content="Stories, testimonies, and the lived consequences of standing for Palestine.">
     <link rel="icon" href="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" type="image/png">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Echoes of Gaza">
     <meta property="og:title" content="Voices from Echoes of Gaza">
-    <meta property="og:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta property="og:description" content="Stories, testimonies, and the lived consequences of standing for Palestine.">
     <meta property="og:url" content="https://echoesofgaza.org/blog">
     <meta property="og:image" content="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png">
     <meta property="og:image:secure_url" content="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png">
     <meta property="og:image:alt" content="Echoes of Gaza favicon">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="Voices from Echoes of Gaza">
-    <meta name="twitter:description" content="Analysis, commentary, and updates from the archival team and invited scholars.">
+    <meta name="twitter:description" content="Stories, testimonies, and the lived consequences of standing for Palestine.">
     <meta name="twitter:image" content="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png">
     <script>
         (function applyPostSpecificHeadMetadata() {
@@ -34,7 +34,7 @@
                 }
                 : {
                     title: "Voices from Echoes of Gaza",
-                    description: "Analysis, commentary, and updates from the archival team and invited scholars.",
+                    description: "Stories, testimonies, and the lived consequences of standing for Palestine.",
                     url: "https://echoesofgaza.org/blog",
                     image: "https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png",
                     imageAlt: "Echoes of Gaza favicon",
@@ -265,7 +265,7 @@
                 </h1>
                 
                 <p class="text-ash-gray text-sm md:text-base max-w-lg leading-relaxed font-sans">
-                    Analysis, commentary, and updates from the archival team and invited scholars.
+                    Stories, testimonies, and the lived consequences of standing for Palestine.
                 </p>
             </div>
             
@@ -374,7 +374,7 @@
 
         const container = document.getElementById('app-container');
         const SITE_TITLE = "Voices from Echoes of Gaza";
-        const SITE_DESCRIPTION = "Analysis, commentary, and updates from the archival team and invited scholars.";
+        const SITE_DESCRIPTION = "Stories, testimonies, and the lived consequences of standing for Palestine.";
         const SITE_URL = "https://echoesofgaza.org/blog";
         const SITE_FAVICON = "https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png";
 

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -244,7 +244,7 @@
                 </h1>
 
                 <p class="text-ash-gray text-sm md:text-base max-w-lg leading-relaxed font-sans">
-                    Analysis, commentary, and updates from the archival team and invited scholars.
+                    Stories, testimonies, and the lived consequences of standing for Palestine.
                 </p>
             </div>
 
@@ -355,7 +355,7 @@
 
         const container = document.getElementById('app-container');
         const SITE_TITLE = "Voices from Echoes of Gaza";
-        const SITE_DESCRIPTION = "Analysis, commentary, and updates from the archival team and invited scholars.";
+        const SITE_DESCRIPTION = "Stories, testimonies, and the lived consequences of standing for Palestine.";
         const SITE_URL = "https://echoesofgaza.org/blog";
         const SITE_FAVICON = "https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png";
 


### PR DESCRIPTION
### Motivation
- Refresh the blog header and metadata copy to the requested phrasing so the site framing reads: "Stories, testimonies, and the lived consequences of standing for Palestine.".

### Description
- Replaced the previous description text with the new copy in `blog.html` and `blog/incident-at-beth-jacob.html` including the visible masthead paragraph and footer duplication. 
- Updated page metadata fields (`meta[name="description"]`, `og:description`, `twitter:description`) and the in-page JS metadata fallback inside `applyPostSpecificHeadMetadata` in `blog.html` to keep sharing text consistent. 
- Updated the `SITE_DESCRIPTION` JS constant in both `blog.html` and `blog/incident-at-beth-jacob.html` so runtime metadata also reflects the new phrasing.

### Testing
- Ran the replacement script which reported `blog.html: 6 replacements` and `blog/incident-at-beth-jacob.html: 2 replacements` and completed without error. 
- Verified presence of the new string with `rg -n` across `blog.html` and `blog/incident-at-beth-jacob.html` which returned the updated locations. 
- Confirmed repository status with `git status --short` and created a commit via `git commit`, which completed showing `2 files changed, 8 insertions(+), 8 deletions(-)`.
- All automated checks and searches succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2849bfd4832990f807b7bb719866)