### PR TITLE
Rename blog masthead label from "Blog" to "Voices"

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -276,7 +276,7 @@
                 </div>
                 
                 <h1 class="font-serif text-3xl md:text-5xl font-bold text-off-white tracking-tight leading-none">
-                    <a href="https://echoesofgaza.org" class="hover:underline decoration-deep-red underline-offset-8 transition-all">Echoes of Gaza</a>: Blog
+                    <a href="https://echoesofgaza.org" class="hover:underline decoration-deep-red underline-offset-8 transition-all">Echoes of Gaza</a>: Voices
                 </h1>
                 
                 <p class="text-ash-gray text-sm md:text-base max-w-lg leading-relaxed font-sans">

--- a/blog/incident-at-beth-jacob.html
+++ b/blog/incident-at-beth-jacob.html
@@ -245,7 +245,7 @@
                 </div>
 
                 <h1 class="font-serif text-3xl md:text-5xl font-bold text-off-white tracking-tight leading-none">
-                    <a href="https://echoesofgaza.org" class="hover:underline decoration-deep-red underline-offset-8 transition-all">Echoes of Gaza</a>: Blog
+                    <a href="https://echoesofgaza.org" class="hover:underline decoration-deep-red underline-offset-8 transition-all">Echoes of Gaza</a>: Voices
                 </h1>
 
                 <p class="text-ash-gray text-sm md:text-base max-w-lg leading-relaxed font-sans">


### PR DESCRIPTION
### Motivation
- Make the blog masthead copy reflect a focus on personal accounts by changing the label from "Blog" to "Voices" on the main blog page and a specific post.

### Description
- Replaced the heading text `Echoes of Gaza</a>: Blog` with `Echoes of Gaza</a>: Voices` in `blog.html` and `blog/incident-at-beth-jacob.html`.
- Kept the subtitle `Stories, testimonies, and the lived consequences of standing for Palestine.` unchanged.
- This is a text-only content update with no structural or behavioral changes.

### Testing
- Used `rg -n` to locate the original strings and confirm occurrences before and after the change, which succeeded.
- Ran a small Python replacement script to apply the edits, which completed without error.
- Verified the updated files by printing relevant lines with `nl`/`sed` to confirm the new heading appears in both files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd309966548329af0e5e6b843d84ab)