### PR TITLE
Update toolkit hero background image to JusticeInfo asset

### DIFF
--- a/toolkit.html
+++ b/toolkit.html
@@ -172,7 +172,7 @@
                 </div>
         
                 <!-- Hero Image -->
-                <div class="w-full aspect-[21/9] md:aspect-[2.5/1] min-h-[300px] overflow-hidden relative bg-cover bg-center documentary-img border border-ash bg-[#111]" style="background-image: url('https://www.ap.org/wp-content/uploads/2024/10/24269687477630.jpg');">
+                <div class="w-full aspect-[21/9] md:aspect-[2.5/1] min-h-[300px] overflow-hidden relative bg-cover bg-center documentary-img border border-ash bg-[#111]" style="background-image: url('https://www.justiceinfo.net/wp-content/uploads/Palestine_Gaza-Jabalia-refugee-camp-destroyed_@Omar-Al-Qattaa-AFP-1000x667.jpg');">
                     <div class="absolute inset-0 bg-black/30"></div>
                     <div class="absolute bottom-4 left-4 md:bottom-6 md:left-6 z-10">
                         <p class="font-semibold text-[9px] md:text-[10px] uppercase tracking-widest text-bone bg-black/80 px-3 py-2 backdrop-blur-sm border border-[#333]">Ref: 01A-Destroyed-Infrastructure</p>


### PR DESCRIPTION
### Motivation
- Replace the AP-hosted hero image on the Toolkit page with the provided JusticeInfo-hosted Gaza image.

### Description
- Updated the `background-image` URL in `toolkit.html` (documentary hero section) to the JusticeInfo asset URL `https://www.justiceinfo.net/wp-content/uploads/Palestine_Gaza-Jabalia-refugee-camp-destroyed_@Omar-Al-Qattaa-AFP-1000x667.jpg`.

### Testing
- Ran `rg -n "justiceinfo.net|24269687477630.jpg" toolkit.html` and `nl -ba toolkit.html | sed -n '168,182p'` to verify the new URL is present and the old URL was removed, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a27d1c0c83298787bf376b48d8ba)