### PR TITLE
Fix disconnected desktop nav dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 # Internal working material — never publish (GitHub Pages serves the whole repo)
 _drafts/
 tips_for_refresh.txt
+.claude/

--- a/assets/site-shell.css
+++ b/assets/site-shell.css
@@ -43,6 +43,7 @@ body.site-shell-pad {
 
 .site-shell-nav {
   display: flex;
+  align-self: stretch;
   align-items: center;
   gap: 28px;
 }
@@ -63,6 +64,9 @@ body.site-shell-pad {
 
 .site-shell-menu-wrap {
   position: relative;
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
 }
 
 .site-shell-menu-button,
@@ -95,7 +99,6 @@ body.site-shell-pad {
   left: 50%;
   top: 100%;
   min-width: 190px;
-  padding-top: 14px;
   transform: translateX(-50%);
   display: none;
   z-index: 5010;

--- a/collab.html
+++ b/collab.html
@@ -365,7 +365,7 @@
             border-color: #4d1b1b;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="min-h-screen flex flex-col">
 

--- a/content_calendar.html
+++ b/content_calendar.html
@@ -54,7 +54,7 @@
             overflow: hidden;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="min-h-screen bg-[#FDFBF7] font-sans text-stone-900 selection:bg-emerald-100 selection:text-emerald-900 pb-16">
 

--- a/echoesindayton.html
+++ b/echoesindayton.html
@@ -21,7 +21,7 @@
         .font-serif { font-family: 'Playfair Display', serif; }
         .font-sans { font-family: 'Inter', sans-serif; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="min-h-screen bg-[#0B0B0B] text-[#EDEDED] selection:bg-[#8C0D0D] selection:text-[#EDEDED]">
 

--- a/events.html
+++ b/events.html
@@ -156,7 +156,7 @@
             scroll-margin-top: 6rem;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="flex flex-col min-h-screen">
 

--- a/index.html
+++ b/index.html
@@ -1749,7 +1749,7 @@
         .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">

--- a/indexLITE.html
+++ b/indexLITE.html
@@ -367,7 +367,7 @@
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">

--- a/podcast.html
+++ b/podcast.html
@@ -148,7 +148,7 @@
             transform: translateY(0);
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="antialiased min-h-screen flex flex-col items-center">
 

--- a/primary.html
+++ b/primary.html
@@ -106,7 +106,7 @@
             background-color: #601414;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="bg-void text-bone min-h-screen font-body selection:bg-blood selection:text-white antialiased">
 

--- a/toolkit.html
+++ b/toolkit.html
@@ -107,7 +107,7 @@
             -webkit-box-decoration-break: clone;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="leading-loose">
 

--- a/zionism_divide.html
+++ b/zionism_divide.html
@@ -222,7 +222,7 @@
         }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-contrast-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
 <body class="antialiased pb-20">
 


### PR DESCRIPTION
## Problem
On desktop, the Archive/Tools/Resources dropdown panels rendered with a visible gap below the header bar, so they looked disconnected from the nav.

## Cause
`.site-shell-menu-wrap` only wrapped the button text (vertically centered in the 60px header), so `top: 100%` positioned the dropdown from the text baseline rather than the header's bottom edge. The 14px `padding-top` hover-bridge then pushed the solid panel further down, creating the gap.

## Fix
Stretch `.site-shell-nav` and `.site-shell-menu-wrap` to the full header height so `top: 100%` anchors the panel flush against the header's bottom edge. The stretched (transparent) wrap area now acts as the hover bridge, so the `padding-top: 14px` is removed. Buttons remain vertically centered and aligned with sibling links.

Also bumped the `site-shell.css?v=` cache-busting token across all 10 pages so visitors receive the updated CSS.

## Verification
Rendered locally at 1280×800:
- panel top now equals header bottom exactly (visible gap: 0px, was ~14px)
- Archive/Tools buttons stay centered (center-Y matches sibling links)
- mobile nav unaffected (desktop nav is `display:none` below 768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)