### PR TITLE
Fix toolkit.html overlap with shared site header/footer

### DIFF
--- a/toolkit.html
+++ b/toolkit.html
@@ -108,11 +108,21 @@
         }
     </style>
     <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
+    <style>
+        /* This page has a fixed left section sidebar; offset the shared site footer
+           to clear it on desktop so the footer matches the layout of the main content. */
+        @media (min-width: 768px) {
+            [data-site-shell="footer"] { margin-left: 12rem; }
+        }
+        @media (min-width: 1024px) {
+            [data-site-shell="footer"] { margin-left: 14rem; }
+        }
+    </style>
 </head>
 <body class="leading-loose">
 
-    <!-- Mobile Top Navigation -->
-    <header class="md:hidden fixed w-full top-0 z-50 bg-[rgba(11,11,11,0.95)] backdrop-blur-md border-b border-[#222]">
+    <!-- Mobile Top Navigation (offset below the shared site header) -->
+    <header class="md:hidden fixed w-full top-[60px] z-40 bg-[rgba(11,11,11,0.95)] backdrop-blur-md border-b border-[#222]">
         <div class="max-w-4xl mx-auto px-4 sm:px-6">
             <div class="flex justify-between items-center h-16">
                 <div class="flex flex-col">
@@ -133,8 +143,8 @@
         </div>
     </header>
 
-    <!-- Desktop Vertical Sidebar -->
-    <aside class="hidden md:flex flex-col fixed left-0 top-0 h-screen w-48 lg:w-56 border-r border-[#222] bg-[rgba(11,11,11,0.95)] backdrop-blur-md p-6 lg:p-8 z-50">
+    <!-- Desktop Vertical Sidebar (offset below the shared site header) -->
+    <aside class="hidden md:flex flex-col fixed left-0 top-[60px] h-[calc(100vh-60px)] w-48 lg:w-56 border-r border-[#222] bg-[rgba(11,11,11,0.95)] backdrop-blur-md p-6 lg:p-8 z-40">
         <div class="flex flex-col mb-16">
             <span class="text-brand-red font-serif font-bold text-sm tracking-widest uppercase leading-tight mb-2">Toolkit Index</span>
             <a href="https://echoesofgaza.org" class="text-[10px] text-bone hover:text-brand-red transition-colors uppercase tracking-widest leading-relaxed">An Echoes of Gaza Project</a>


### PR DESCRIPTION
## Context
Follow-up to the request to make all non-excluded pages share the same header and footer.

I audited every non-excluded page (index, indexLITE, primary, collab, events, podcast, toolkit, zionism_divide, echoesindayton) by rendering them and inspecting the post-injection DOM. **All of them already render the shared site-shell header, mobile menu, and footer identically — except toolkit.html.**

## Problem
toolkit.html has its own fixed section navigator (left sidebar on desktop, top bar on mobile) pinned at `top:0`, which collided with the shared shell header (fixed, 60px tall):
- desktop: the sidebar's "Toolkit Index" label was hidden behind the shell header, and the shell footer's left column sat behind the fixed sidebar
- mobile: the toolkit top bar double-stacked with the shell's menu button

## Fix (scoped to toolkit.html)
- Offset the sidebar and mobile section bar below the 60px shell header (`top:60px`, height calc) and lower their z-index below the shell.
- Offset the shared footer past the fixed sidebar on desktop (`margin-left: 12rem/14rem`), matching the main content's `md:ml-48 lg:ml-56`.

## Verification (rendered at 1280×800 and 375×812)
- desktop: shell header on top; "Toolkit Index" sidebar now starts cleanly below it; footer left edge = sidebar right edge (224px), no horizontal overflow
- mobile: shell header + menu button on top, toolkit section bar stacked neatly beneath it, no overlap

Excluded pages (brochure, press releases, content calendar, blogs incl. blog_submit) were left untouched per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)