### PR TITLE
Fix displacement-map scroll-jacking & restore Voices in nav dropdown

### DIFF
--- a/collab.html
+++ b/collab.html
@@ -1503,6 +1503,6 @@
           }
         });
       </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/content_calendar.html
+++ b/content_calendar.html
@@ -641,6 +641,6 @@ async function apiDeletePost(id) {
         loadData();
         
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/echoesindayton.html
+++ b/echoesindayton.html
@@ -276,6 +276,6 @@
             });
         });
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -552,6 +552,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1748,6 +1748,49 @@
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 
+        /* Click-to-load cover for the displacement map. The arcg.is embed steals
+           scroll when it loads, so the map is loaded only on user request rather
+           than auto-loading while scrolling past it. */
+        .eog-map-cover {
+            position: absolute;
+            inset: 0;
+            z-index: 2;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 14px;
+            width: 100%;
+            border: 0;
+            cursor: pointer;
+            text-align: center;
+            background:
+                radial-gradient(ellipse 80% 60% at 50% 45%, rgba(26, 3, 5, 0.55) 0%, rgba(5, 5, 5, 0.92) 75%),
+                #0a0a0a;
+            transition: opacity 0.3s ease;
+        }
+        .eog-map-cover-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.05rem;
+            color: rgba(255, 255, 255, 0.9);
+        }
+        .eog-map-cover-cta {
+            font-size: 0.7rem;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: #0a0a0a;
+            background: var(--eog-gold, #c9a84c);
+            padding: 10px 22px;
+            border-radius: 3px;
+            font-weight: 600;
+        }
+        .eog-map-cover:hover .eog-map-cover-cta { opacity: 0.88; }
+        .eog-map-cover-note {
+            font-size: 0.62rem;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.45);
+        }
     </style>
     <link rel="stylesheet" href="./assets/site-shell.css?v=nav-dropdown-2">
 </head>
@@ -2214,8 +2257,13 @@
         <section id="gaza-displacement-maps" class="py-12 bg-[#050505] border-y border-white/5">
             <div class="container mx-auto px-6">
                 <h3 class="text-2xl font-serif font-bold mb-16 text-center text-white/90">Displacement & Kill Zones</h3>
-                <div class="max-w-5xl mx-auto w-full h-[80vh] border border-white/10 overflow-hidden bg-[#0a0a0a] relative">
-                    <iframe class="map-lazy-embed w-full h-full" data-map-src="https://arcg.is/0TeG4L" width="100%" height="100%" frameborder="0" scrolling="no" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen webkitallowfullscreen mozallowfullscreen title="Gaza Maps IDF Forced Displacement"></iframe>
+                <div id="displacement-map-frame" class="max-w-5xl mx-auto w-full h-[80vh] border border-white/10 overflow-hidden bg-[#0a0a0a] relative">
+                    <iframe class="map-lazy-embed w-full h-full" data-map-src="https://arcg.is/0TeG4L" width="100%" height="100%" frameborder="0" scrolling="no" tabindex="-1" sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen webkitallowfullscreen mozallowfullscreen title="Gaza Maps IDF Forced Displacement"></iframe>
+                    <button type="button" id="displacement-map-load" class="eog-map-cover" aria-label="Load the interactive displacement map">
+                        <span class="eog-map-cover-title">Displacement &amp; Kill Zones</span>
+                        <span class="eog-map-cover-cta">Load interactive map</span>
+                        <span class="eog-map-cover-note">Gaza Maps embed</span>
+                    </button>
                 </div>
                 <div class="text-center mt-6">
                     <p class="text-xs text-gray-600 uppercase tracking-widest">Map provided by <a href="https://gazamaps.com/" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-white transition underline decoration-1 underline-offset-4">Gaza Maps</a>, a project by Databases for Palestine.</p>
@@ -3695,8 +3743,21 @@
             if (src) iframe.src = src;
         }
 
+        function revealDisplacementMap() {
+            const frame = document.getElementById('displacement-map-frame');
+            if (!frame) return;
+            frame.querySelectorAll('iframe[data-map-src]').forEach(loadLazyMapEmbed);
+            const cover = document.getElementById('displacement-map-load');
+            if (cover) cover.style.display = 'none';
+        }
+
         function initLazyMapEmbeds() {
-            const embeds = Array.from(document.querySelectorAll('iframe[data-map-src]'));
+            // The displacement map (arcg.is) steals scroll when it loads, which
+            // yanked the page back up while scrolling past it. It is excluded
+            // from auto-loading and loads only on explicit request (cover button
+            // or the kill-zone link).
+            const embeds = Array.from(document.querySelectorAll('iframe[data-map-src]'))
+                .filter((iframe) => !iframe.closest('#displacement-map-frame'));
             if (!embeds.length) return;
 
             if (!('IntersectionObserver' in window)) {
@@ -3723,7 +3784,7 @@
             const section = document.getElementById('gaza-displacement-maps');
             if (!section) return;
             document.documentElement.classList.remove('eog-home-map-section-lock');
-            section.querySelectorAll('iframe[data-map-src]').forEach(loadLazyMapEmbed);
+            revealDisplacementMap();
             section.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
 
@@ -4467,6 +4528,7 @@
             }
             setupDropdowns();
             setupHiddenToolNavigation();
+            document.getElementById('displacement-map-load')?.addEventListener('click', revealDisplacementMap);
             initLazyMapEmbeds();
             initMobileDensityControl();
             initDesktopDisplayZoomControl();
@@ -4978,6 +5040,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/indexLITE.html
+++ b/indexLITE.html
@@ -2045,6 +2045,6 @@ document.addEventListener('DOMContentLoaded', loadArticles);
             root.render(<StoryGenerator />);
         }
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/podcast.html
+++ b/podcast.html
@@ -437,6 +437,6 @@
             }, 2000);
         }
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/primary.html
+++ b/primary.html
@@ -696,6 +696,6 @@
         });
 
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/toolkit.html
+++ b/toolkit.html
@@ -1155,6 +1155,6 @@
             setTimeout(updateNav, 100);
         });
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>

--- a/zionism_divide.html
+++ b/zionism_divide.html
@@ -768,6 +768,6 @@
     <script>
         lucide.createIcons();
     </script>
-    <script src="./assets/site-shell.js?v=integrity-1" defer></script>
+    <script src="./assets/site-shell.js?v=voices-1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Two bug fixes, independent of the design PR so they can ship on their own.

## 1. Displacement map yanks the page back up
The "Displacement & Kill Zones" (arcg.is) embed steals scroll focus when it finishes loading. Because it auto-loaded as you scrolled toward it, the page kept getting yanked back up to the map.

**Fix:** the map no longer auto-loads. It's excluded from the lazy-load observer and loads only on request — via a new lightweight **"Load interactive map"** cover, or the existing kill-zone stat link. The iframe also gets `tabindex="-1"`. Verified: scrolling past no longer moves the page; clicking the cover loads the map and hides the cover.

## 2. "Voices" missing from the Resources dropdown
`site-shell.js` already lists Voices under Resources, but the script's cache-busting version (`?v=integrity-1`) was never bumped when Voices was added — so browsers kept serving a stale nav without it.

**Fix:** bump `site-shell.js?v=integrity-1` → `voices-1` across all 10 pages so the current nav (with Voices) is fetched. Verified the Resources dropdown now lists: Quotes & Resources, **Voices**, Events, FAQ.

No console errors. (Both verified via computed DOM state in a local render.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)