### PR TITLE
Restore article action buttons in compact view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1493,7 +1493,11 @@
 
             html[data-mobile-density="2x"] .article-card-footer,
             html[data-mobile-density="3x"] .article-card-footer {
-                display: none;
+                display: grid;
+                grid-template-columns: minmax(0, 1fr);
+                gap: 0.45rem;
+                padding-top: 0.55rem;
+                margin-top: 0.55rem;
             }
 
             html[data-mobile-density="2x"] .article-author-line,
@@ -1503,8 +1507,9 @@
 
             html[data-mobile-density="2x"] .article-actions,
             html[data-mobile-density="3x"] .article-actions {
-                grid-template-columns: 1fr;
-                gap: 0.35rem;
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+                gap: 0.25rem;
+                width: 100%;
             }
 
             html[data-mobile-density="2x"] .article-action-btn,


### PR DESCRIPTION
### Motivation
- The 2x/3x mobile-density CSS was hiding the `.article-card-footer`, which removed the Details/Story/Share buttons from article cards in compact (dense) archive views.
- The intent is to keep a compact mobile layout while preserving access to the three action buttons for each article.

### Description
- Replaced the dense-mode rule that set `.article-card-footer` to `display: none` with a compact `display: grid` layout and spacing so the footer (actions) remains visible in `data-mobile-density="2x"` and `"3x"` modes.
- Kept the compact appearance by hiding the `.article-author-line` in dense mode and changing `.article-actions` to a 3-column tight grid (`repeat(3, minmax(0, 1fr))`) so `Details`, `Story`, and `Share` remain accessible.
- Change was made in `index.html` (CSS block around the mobile-density rules and the article action layout) so the card markup that calls `window.openArticleDetail`, `window.openStoryCreator`, and `window.toggleShareMenu` is visible and usable in compact views.

### Testing
- Ran `node --check scripts/validate_data.mjs` and `node scripts/validate_data.mjs` to validate data files, both succeeded.
- Executed a Python inline assertion that verified the presence of the compact-density CSS and the article action markup, which succeeded.
- Ran `git diff --check` to ensure no whitespace/errors in diffs, which returned clean.
- Attempted browser-based screenshot/playwright testing but tooling is not installed in this environment, so visual verification was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c15541fac83299591a054a0e59762)