### PR TITLE
collab: fix metadata fetch & add bottom 'Add another article' button

### DIFF
--- a/collab.html
+++ b/collab.html
@@ -596,6 +596,9 @@
                         <button type="button" id="addArticleButton" class="small-interface-button">Add Article</button>
                     </div>
                     <div id="additionalArticles" class="space-y-6"></div>
+                    <div class="flex justify-center mt-6">
+                        <button type="button" id="addArticleButtonBottom" class="small-interface-button">Add another article</button>
+                    </div>
                 </section>
 
                 <!-- Optional Fields -->
@@ -1245,16 +1248,31 @@
             }
         }
 
+        function looksLikeArticleHtml(text) {
+            return typeof text === "string" && /<\s*(meta|title|html|head)\b/i.test(text);
+        }
+
         async function fetchArticleHtml(url) {
+            // Most publishers block direct cross-origin requests, so fall back through
+            // several public CORS proxies. Order matters: try direct first (works for
+            // permissive sites), then the most reliable proxies. Each candidate is
+            // validated to be real HTML before accepting it.
             const proxyUrls = [
                 url,
+                `https://corsproxy.io/?url=${encodeURIComponent(url)}`,
                 `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
-                `https://corsproxy.io/?${encodeURIComponent(url)}`
+                `https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(url)}`,
+                `https://thingproxy.freeboard.io/fetch/${url}`
             ];
             let lastError;
             for (const requestUrl of proxyUrls) {
                 try {
-                    return await fetchWithTimeout(requestUrl);
+                    // The direct attempt rarely succeeds for publishers (CORS), so give it
+                    // a short timeout and let the proxies do the real work.
+                    const timeoutMs = requestUrl === url ? 5000 : 12000;
+                    const text = await fetchWithTimeout(requestUrl, {}, timeoutMs);
+                    if (looksLikeArticleHtml(text)) return text;
+                    lastError = new Error("Response did not contain readable page HTML.");
                 } catch (error) {
                     lastError = error;
                 }
@@ -1464,6 +1482,12 @@
                 </div>
             `;
             additionalArticles.appendChild(wrapper);
+            // Bring the new article (and the bottom "Add another article" button)
+            // into view so multiple articles can be added without scrolling up.
+            requestAnimationFrame(() => {
+                wrapper.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                wrapper.querySelector('[data-field="link"]')?.focus({ preventScroll: true });
+            });
         }
 
         function setMultiArticleMode(isEnabled) {
@@ -1732,6 +1756,7 @@
 
         multiArticleMode.addEventListener('change', (event) => setMultiArticleMode(event.target.checked));
         addArticleButton.addEventListener('click', createExtraArticleBlock);
+        document.getElementById('addArticleButtonBottom')?.addEventListener('click', createExtraArticleBlock);
         setBatchEntryEvents();
     </script>
     <script type="module">


### PR DESCRIPTION
Two fixes on the Submit Evidence (collab) page. No submission, Firebase, or Apps Script logic touched.

## 1. "Fetch Details" only worked for Associated Press
The auto-fill fetches the article page's HTML through CORS proxies and reads its meta tags. It was effectively broken for every source — AP only *appeared* to work because there's a hardcoded AP image/source fallback that fills in even when the fetch fails.

Root cause: **corsproxy.io changed its API to require `?url=`**, but the code still used the old `?<url>` form, so that proxy silently failed; the only other proxy (allorigins) is too rate-limited/flaky to rely on.

Fix:
- Correct the corsproxy format to `?url=` and try it first.
- Add codetabs + thingproxy as additional fallbacks.
- Validate each response is real HTML before accepting it.
- Give the (usually CORS-blocked) direct attempt a short 5s timeout so the working proxy runs sooner.

Verified end-to-end: a UN News link auto-filled title, source, date, summary, image, and type; fetch time dropped from ~20s to ~9s.

## 2. "Add another article" required scrolling back to the top
Added a second **Add another article** button beneath the article list (the top one stays too), and each newly added article now scrolls into view with its link field focused — so you can add several articles in a row from the bottom.

Verified in-browser: adding articles from the bottom button works, the button stays below the most recent article, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)