### PR TITLE
[codex] Refine archive research and add About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="About Echoes of Gaza, its archival principles, research tools, sourcing practices, and frequently asked questions.">
+  <meta property="og:title" content="About Echoes of Gaza">
+  <meta property="og:description" content="How Echoes of Gaza preserves a sourced, public record of Palestinian life, loss, displacement, and resistance.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://echoesofgaza.org/about">
+  <meta property="og:image" content="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png">
+  <title>About | Echoes of Gaza</title>
+  <link rel="icon" href="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" type="image/png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./assets/site-tokens.css?v=design-1">
+  <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+  <link rel="stylesheet" href="./assets/about.css?v=1">
+</head>
+<body>
+  <main class="about-main">
+    <section class="about-hero">
+      <div class="about-shell about-hero-grid">
+        <div>
+          <span class="about-kicker">About the archive</span>
+          <h1>A record built to outlast the news cycle.</h1>
+          <p class="about-hero-lead">Echoes of Gaza is a public digital archive preserving sourced reporting, testimony, research, and visual evidence about Palestine—so that events remain findable, traceable, and harder to erase.</p>
+          <p class="about-hero-note">The archive does not ask visitors to accept a summary without inspection. Records retain their source, date, authorship, topic, document type, and—where available—an archived copy.</p>
+        </div>
+        <div class="about-mark" aria-label="Echoes of Gaza mark">
+          <img src="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png" alt="Echoes of Gaza logo">
+        </div>
+      </div>
+    </section>
+
+    <section class="about-section">
+      <div class="about-shell">
+        <div class="about-intro">
+          <div>
+            <span class="about-section-label">Why it exists</span>
+            <h2>Memory is part of accountability.</h2>
+          </div>
+          <div class="about-copy">
+            <p>Echoes of Gaza was created in response to a familiar pattern: Palestinian suffering is documented in real time, then fragmented across disappearing links, shortened news cycles, inaccessible databases, and competing narratives. What is difficult to find becomes easier to deny.</p>
+            <p>This project gathers that record without flattening it. A news investigation is not treated as the same kind of evidence as a legal filing, a humanitarian update, or firsthand testimony. Each record should be read for what it is, alongside its date, source, methods, and limits.</p>
+          </div>
+        </div>
+        <div class="about-principles">
+          <article class="about-principle">
+            <span>01 · Preserve</span>
+            <h3>Keep the record reachable</h3>
+            <p>Links change and pages disappear. Archive-status labels and preserved copies help visitors understand what remains available.</p>
+          </article>
+          <article class="about-principle">
+            <span>02 · Contextualize</span>
+            <h3>Keep evidence attached to its source</h3>
+            <p>Dates, authors, publishers, document types, and topical categories make it possible to inspect a record rather than merely repeat it.</p>
+          </article>
+          <article class="about-principle">
+            <span>03 · Humanize</span>
+            <h3>Keep people visible inside the data</h3>
+            <p>The archive holds policy and evidence alongside names, testimony, cultural work, and lived experience. Scale must never erase personhood.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="about-section about-features">
+      <div class="about-shell">
+        <div class="about-heading-row">
+          <div>
+            <span class="about-section-label">Using the archive</span>
+            <h2>Tools for careful reading.</h2>
+          </div>
+          <p>Every feature is meant to shorten the distance between a question and the underlying source—not to replace independent judgment.</p>
+        </div>
+        <div class="about-feature-list">
+          <article class="about-feature">
+            <span class="about-feature-number">01</span>
+            <h3>Search and filters</h3>
+            <p>Search across titles, summaries, sources, authors, and topics, then narrow the result by date, publisher, category, or document type.</p>
+          </article>
+          <article class="about-feature">
+            <span class="about-feature-number">02</span>
+            <h3>Evidence threads</h3>
+            <p>Guided chronological paths connect directly relevant records around displacement, aid and hunger, and the conditions under which journalists preserve the public record.</p>
+          </article>
+          <article class="about-feature">
+            <span class="about-feature-number">03</span>
+            <h3>Research packet</h3>
+            <p>Save records while browsing. A compact cited notepad follows the page and builds a local research list in Plain, MLA, APA, or Chicago format.</p>
+          </article>
+          <article class="about-feature">
+            <span class="about-feature-number">04</span>
+            <h3>Source availability</h3>
+            <p>Labels distinguish a live source, an archived copy, a moved page, or a source that has changed. They describe availability and provenance, not a blanket judgment about every claim.</p>
+          </article>
+          <article class="about-feature">
+            <span class="about-feature-number">05</span>
+            <h3>Witness Mode</h3>
+            <p>A focused reading view removes the surrounding grid and presents one record at a time for visitors who want to slow down and read without visual overload.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="about-section about-faq">
+      <div class="about-shell">
+        <div class="about-faq-header">
+          <span class="about-section-label">Frequently asked questions</span>
+          <h2>How the archive works.</h2>
+          <p>Clear answers about sourcing, citations, privacy, corrections, and the research tools available across the site.</p>
+        </div>
+        <div class="about-faq-list">
+          <details>
+            <summary>What is Echoes of Gaza?</summary>
+            <div class="about-faq-answer">Echoes of Gaza is an independent, public digital historical archive focused on the ongoing occupation, displacement, destruction, and genocide of the Palestinian people. It brings together reporting, humanitarian documentation, legal analysis, testimony, books, film, and other media in a searchable record.</div>
+          </details>
+          <details>
+            <summary>Why was the project created?</summary>
+            <div class="about-faq-answer">Because documentation can be scattered, removed, paywalled, or forgotten after headlines move on. The project preserves a traceable record that researchers, journalists, educators, students, advocates, and members of the public can return to over time.</div>
+          </details>
+          <details>
+            <summary>How are records selected and described?</summary>
+            <div class="about-faq-answer">Records are cataloged with the source, publication date, author when available, a short summary, categories, and document type. Inclusion means the item is relevant to the archive’s subject; it does not mean every statement in every source has been independently adopted as an institutional conclusion.</div>
+          </details>
+          <details>
+            <summary>What do the archive-status labels mean?</summary>
+            <div class="about-faq-answer">Availability labels explain whether a live page is reachable, whether an archived copy exists, or whether a source appears to have moved, changed, or disappeared. These labels help preserve provenance. They are not truth scores.</div>
+          </details>
+          <details>
+            <summary>How do evidence threads differ from search results?</summary>
+            <div class="about-faq-answer">Search results are broad and respond to your terms and filters. Evidence threads are intentionally smaller chronological selections chosen for direct relevance and continuity. They are starting points for research, not complete accounts.</div>
+          </details>
+          <details>
+            <summary>How does the research packet work?</summary>
+            <div class="about-faq-answer">Select “Save” on an article card or source detail. Once the first record is saved, a small floating notepad appears and follows the page. It stores the selected records in your browser and displays each citation in the format you choose. No account is required.</div>
+          </details>
+          <details>
+            <summary>Are generated citations ready to publish?</summary>
+            <div class="about-faq-answer">They are a practical draft. Citation rules vary by institution and source type, and archive metadata can be incomplete. Always compare a generated citation with the original publication and the style guide required for your work.</div>
+          </details>
+          <details>
+            <summary>Does the site track what I save?</summary>
+            <div class="about-faq-answer">The research packet is stored locally in your browser using local storage. It is designed to work without an account. Clearing the packet or your browser’s site data removes that saved list from the device.</div>
+          </details>
+          <details>
+            <summary>Can I use archive materials in research, teaching, or media?</summary>
+            <div class="about-faq-answer">Yes, with appropriate attribution and respect for the rights attached to each original source. Echoes of Gaza catalogs and links to material; it does not replace the original publisher’s copyright, licensing terms, or permissions requirements.</div>
+          </details>
+          <details>
+            <summary>How can I submit evidence or request a correction?</summary>
+            <div class="about-faq-answer">Use the “Submit Evidence” route to provide a source link and supporting metadata. For corrections, include the affected title or URL and explain the specific factual or cataloging issue. Clear, source-backed corrections help keep the archive accountable.</div>
+          </details>
+          <details>
+            <summary>Who is the archive for?</summary>
+            <div class="about-faq-answer">It is for anyone trying to understand, teach, report, investigate, or remember: journalists, researchers, educators, students, legal and human-rights workers, organizers, and members of the public. No specialized background is required to begin.</div>
+          </details>
+          <details>
+            <summary>Why does this work matter now?</summary>
+            <div class="about-faq-answer">Accountability depends on records that can still be found, checked, and connected over time. Preserving evidence while events are unfolding helps resist erasure and gives future reporting, scholarship, and legal work a stronger factual foundation.</div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="about-section">
+      <div class="about-shell about-cta">
+        <p>The archive remains a living project. Explore the record, follow the sources, and help preserve evidence that should not be allowed to disappear.</p>
+        <a href="./#articles">Enter the archive</a>
+      </div>
+    </section>
+  </main>
+
+  <script src="./assets/site-shell.js?v=about-1" defer></script>
+</body>
+</html>

--- a/assets/about.css
+++ b/assets/about.css
@@ -1,0 +1,383 @@
+:root {
+  --about-paper: #ece7df;
+  --about-ash: #a8a096;
+  --about-dim: #777169;
+  --about-line: rgba(255, 255, 255, 0.08);
+  --about-red: #9b1b30;
+  --about-gold: #c9a84c;
+}
+
+html {
+  scroll-behavior: smooth;
+  background: #050505;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 78% 5%, rgba(139, 0, 0, 0.11), transparent 29rem),
+    #050505;
+  color: var(--about-paper);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.about-main {
+  overflow: hidden;
+}
+
+.about-shell {
+  width: min(76rem, calc(100% - 3rem));
+  margin: 0 auto;
+}
+
+.about-hero {
+  min-height: 78vh;
+  display: grid;
+  align-items: center;
+  padding: clamp(6rem, 12vw, 10rem) 0 5rem;
+  border-bottom: 1px solid var(--about-line);
+}
+
+.about-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 15rem;
+  align-items: center;
+  gap: clamp(3rem, 8vw, 7rem);
+}
+
+.about-kicker,
+.about-section-label {
+  color: var(--about-red);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.about-hero h1 {
+  max-width: 48rem;
+  margin: 0.75rem 0 1.25rem;
+  font-family: "DM Serif Display", Georgia, serif;
+  font-size: clamp(3.4rem, 8vw, 7.4rem);
+  font-weight: 400;
+  letter-spacing: -0.035em;
+  line-height: 0.96;
+}
+
+.about-hero-lead {
+  max-width: 43rem;
+  color: #c0b8ad;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+  line-height: 1.75;
+}
+
+.about-hero-note {
+  max-width: 37rem;
+  margin-top: 1.25rem;
+  color: var(--about-dim);
+  font-size: 0.78rem;
+  line-height: 1.7;
+}
+
+.about-mark {
+  position: relative;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(201, 168, 76, 0.28);
+  border-radius: 50%;
+  background: #090909;
+}
+
+.about-mark::before,
+.about-mark::after {
+  content: "";
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: 50%;
+}
+
+.about-mark::before { inset: 0.8rem; }
+.about-mark::after { inset: 1.55rem; }
+
+.about-mark img {
+  position: relative;
+  z-index: 1;
+  width: 56%;
+  height: 56%;
+  object-fit: contain;
+}
+
+.about-section {
+  padding: clamp(4.5rem, 9vw, 7.5rem) 0;
+  border-bottom: 1px solid var(--about-line);
+}
+
+.about-intro {
+  display: grid;
+  grid-template-columns: 15rem minmax(0, 1fr);
+  gap: clamp(2rem, 7vw, 7rem);
+}
+
+.about-intro h2,
+.about-features h2,
+.about-faq h2 {
+  margin: 0;
+  font-family: "DM Serif Display", Georgia, serif;
+  font-size: clamp(2.25rem, 5vw, 4rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.about-copy {
+  max-width: 49rem;
+}
+
+.about-copy p {
+  margin: 0 0 1.35rem;
+  color: #aaa298;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1.02rem;
+  line-height: 1.9;
+}
+
+.about-principles {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 3.25rem;
+  border: 1px solid var(--about-line);
+  background: var(--about-line);
+}
+
+.about-principle {
+  min-height: 14rem;
+  background: #090909;
+  padding: 1.5rem;
+}
+
+.about-principle span {
+  color: var(--about-gold);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.about-principle h3 {
+  margin: 1.8rem 0 0.7rem;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1.2rem;
+}
+
+.about-principle p {
+  margin: 0;
+  color: var(--about-dim);
+  font-size: 0.76rem;
+  line-height: 1.7;
+}
+
+.about-features {
+  background: #080808;
+}
+
+.about-heading-row {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.about-heading-row p {
+  max-width: 29rem;
+  margin: 0;
+  color: var(--about-dim);
+  font-size: 0.78rem;
+  line-height: 1.7;
+}
+
+.about-feature-list {
+  border-top: 1px solid var(--about-line);
+}
+
+.about-feature {
+  display: grid;
+  grid-template-columns: 3rem 13rem minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 1.35rem 0;
+  border-bottom: 1px solid var(--about-line);
+}
+
+.about-feature-number {
+  color: var(--about-gold);
+  font-size: 0.64rem;
+  letter-spacing: 0.12em;
+}
+
+.about-feature h3 {
+  margin: 0;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1rem;
+}
+
+.about-feature p {
+  max-width: 43rem;
+  margin: 0;
+  color: var(--about-dim);
+  font-size: 0.76rem;
+  line-height: 1.7;
+}
+
+.about-faq-header {
+  max-width: 43rem;
+  margin-bottom: 2.5rem;
+}
+
+.about-faq-header p {
+  margin-top: 0.9rem;
+  color: var(--about-dim);
+  font-size: 0.8rem;
+  line-height: 1.7;
+}
+
+.about-faq-list {
+  max-width: 58rem;
+  border-top: 1px solid var(--about-line);
+}
+
+.about-faq details {
+  border-bottom: 1px solid var(--about-line);
+}
+
+.about-faq summary {
+  min-height: 4.5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1.5rem;
+  color: #d8d1c7;
+  cursor: pointer;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1rem;
+  list-style: none;
+}
+
+.about-faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.about-faq summary::after {
+  content: "+";
+  color: var(--about-gold);
+  font-family: Inter, sans-serif;
+  font-size: 1rem;
+  font-weight: 400;
+}
+
+.about-faq details[open] summary::after {
+  content: "−";
+}
+
+.about-faq-answer {
+  max-width: 49rem;
+  padding: 0 2rem 1.5rem 0;
+  color: #918a81;
+  font-size: 0.8rem;
+  line-height: 1.8;
+}
+
+.about-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.about-cta p {
+  max-width: 43rem;
+  margin: 0;
+  color: #aaa298;
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 1.1rem;
+  line-height: 1.75;
+}
+
+.about-cta a {
+  flex: 0 0 auto;
+  border: 1px solid var(--about-red);
+  background: #791322;
+  color: #fff;
+  padding: 0.9rem 1.1rem;
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.about-cta a:hover {
+  background: #8b1728;
+}
+
+@media (max-width: 800px) {
+  .about-shell {
+    width: min(100% - 2rem, 76rem);
+  }
+
+  .about-hero {
+    min-height: 0;
+    padding-top: 6rem;
+  }
+
+  .about-hero-grid,
+  .about-intro {
+    grid-template-columns: 1fr;
+  }
+
+  .about-mark {
+    width: 8rem;
+    grid-row: 1;
+  }
+
+  .about-principles {
+    grid-template-columns: 1fr;
+  }
+
+  .about-principle {
+    min-height: 0;
+  }
+
+  .about-heading-row,
+  .about-cta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .about-feature {
+    grid-template-columns: 2.25rem minmax(0, 1fr);
+  }
+
+  .about-feature p {
+    grid-column: 2;
+  }
+}
+
+@media (max-width: 520px) {
+  .about-hero h1 {
+    font-size: clamp(3rem, 16vw, 4.2rem);
+  }
+
+  .about-feature {
+    gap: 0.85rem;
+  }
+
+  .about-faq summary {
+    min-height: 4rem;
+    font-size: 0.92rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+}

--- a/assets/archive-experience.css
+++ b/assets/archive-experience.css
@@ -1,0 +1,1115 @@
+/* Echoes of Gaza — guided archive experience
+   These additions stay visually subordinate to the documentary archive. */
+
+.archive-methodology {
+  max-width: 58rem;
+  margin: -2.5rem auto 3rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.archive-methodology summary {
+  min-height: 3.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  color: #9c958a;
+  cursor: pointer;
+  font-family: Inter, sans-serif;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  list-style: none;
+  text-transform: uppercase;
+}
+
+.archive-methodology summary::-webkit-details-marker {
+  display: none;
+}
+
+.archive-methodology summary::after {
+  content: "+";
+  color: #c9a84c;
+  font-size: 1rem;
+  font-weight: 400;
+}
+
+.archive-methodology[open] summary::after {
+  content: "−";
+}
+
+.archive-methodology-body {
+  padding: 0 1rem 1.5rem;
+  text-align: left;
+}
+
+.archive-methodology-intro {
+  max-width: 46rem;
+  margin: 0 auto 1.25rem;
+  color: #b8b2a8;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  text-align: center;
+}
+
+.archive-methodology-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.archive-methodology-item {
+  background: #090909;
+  padding: 1rem;
+}
+
+.archive-methodology-item strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #e7e1d8;
+  font-family: Inter, sans-serif;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.archive-methodology-item span {
+  display: block;
+  color: #8f897f;
+  font-size: 0.74rem;
+  line-height: 1.6;
+}
+
+.archive-methodology-reviewed {
+  margin-top: 1rem;
+  color: #716c65;
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.archive-pathways {
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  background: #080808;
+}
+
+.archive-pathways-shell {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem;
+}
+
+.archive-pathways-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 2rem;
+  margin-bottom: 1.75rem;
+}
+
+.archive-pathways-kicker {
+  color: #9b1b30;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.archive-pathways-heading h2 {
+  margin: 0.5rem 0 0;
+  color: #ece7df;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.7rem, 3vw, 2.35rem);
+  line-height: 1.1;
+}
+
+.archive-pathways-heading p {
+  max-width: 37rem;
+  margin-top: 0.7rem;
+  color: #8d877d;
+  font-size: 0.84rem;
+  line-height: 1.7;
+}
+
+.witness-entry-button,
+.archive-help-button {
+  min-height: 2.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #0e0e0e;
+  color: #d5cfc5;
+  padding: 0.75rem 1rem;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.witness-entry-button:hover,
+.archive-help-button:hover {
+  border-color: rgba(201, 168, 76, 0.55);
+  background: #12110e;
+  color: #fff;
+}
+
+.archive-pathway-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.archive-pathway-tab {
+  min-height: 3.4rem;
+  border: 0;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: #0b0b0b;
+  color: #777169;
+  padding: 0.85rem 1rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-align: left;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.archive-pathway-tab:last-child {
+  border-right: 0;
+}
+
+.archive-pathway-tab:hover,
+.archive-pathway-tab[aria-selected="true"] {
+  background: #121212;
+  color: #ece7df;
+}
+
+.archive-pathway-tab[aria-selected="true"] {
+  box-shadow: inset 0 -2px #9b1b30;
+}
+
+.archive-pathway-panel {
+  min-height: 23rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 0;
+  background: #090909;
+  padding: 1.5rem;
+}
+
+.archive-pathway-panel[hidden] {
+  display: none;
+}
+
+.claim-layout,
+.thread-layout {
+  display: grid;
+  grid-template-columns: 18rem minmax(0, 1fr);
+  gap: 2rem;
+}
+
+.pathway-selector {
+  display: grid;
+  align-content: start;
+  gap: 0.45rem;
+}
+
+.pathway-selector-label {
+  margin-bottom: 0.35rem;
+  color: #65615b;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.pathway-select-button {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #89837a;
+  padding: 0.72rem 0.8rem;
+  font-family: "Playfair Display", serif;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  text-align: left;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.pathway-select-button:hover,
+.pathway-select-button.is-active {
+  border-color: rgba(255, 255, 255, 0.09);
+  background: #101010;
+  color: #eee8df;
+}
+
+.pathway-result-header {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pathway-result-header h3 {
+  color: #eee8df;
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+  line-height: 1.25;
+}
+
+.pathway-result-header p {
+  max-width: 47rem;
+  margin-top: 0.55rem;
+  color: #858078;
+  font-size: 0.78rem;
+  line-height: 1.65;
+}
+
+.claim-records {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.claim-record,
+.thread-record {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: #0d0d0d;
+  padding: 1rem;
+  text-align: left;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.claim-record:hover,
+.thread-record:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.claim-record-meta,
+.thread-record-meta {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: #726d65;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.claim-record-title,
+.thread-record-title {
+  display: block;
+  color: #cfc8be;
+  font-family: "Playfair Display", serif;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.thread-line {
+  position: relative;
+  display: grid;
+  gap: 0;
+  padding-left: 1.2rem;
+}
+
+.thread-line::before {
+  content: "";
+  position: absolute;
+  top: 0.45rem;
+  bottom: 0.45rem;
+  left: 0.25rem;
+  width: 1px;
+  background: linear-gradient(#9b1b30, rgba(201, 168, 76, 0.18));
+}
+
+.thread-step {
+  position: relative;
+  padding: 0 0 0.9rem 1rem;
+}
+
+.thread-step::before {
+  content: "";
+  position: absolute;
+  top: 1.25rem;
+  left: -1.2rem;
+  width: 0.45rem;
+  height: 0.45rem;
+  border: 1px solid #c9a84c;
+  border-radius: 50%;
+  background: #090909;
+}
+
+.archive-toolbar-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.archive-toolbar-heading h2 {
+  margin: 0;
+}
+
+.archive-toolbar-heading-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.filter-panel-intro {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.filter-panel-intro h3 {
+  color: #e7e1d8;
+  font-family: "Playfair Display", serif;
+  font-size: 1.15rem;
+}
+
+.filter-panel-intro p {
+  max-width: 34rem;
+  color: #777169;
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.filter-count-badge {
+  display: inline-flex;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.35rem;
+  border-radius: 999px;
+  background: #2b2723;
+  color: #d8d1c7;
+  font-size: 0.58rem;
+}
+
+.active-filter-strip {
+  display: none;
+  align-items: center;
+  gap: 0.55rem;
+  margin: -0.3rem 0 1.2rem;
+}
+
+.active-filter-strip.has-filters {
+  display: flex;
+}
+
+.active-filter-label {
+  flex: 0 0 auto;
+  color: #68635c;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.active-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.active-filter-chip {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #0d0d0d;
+  color: #a49d93;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.62rem;
+}
+
+.active-filter-chip:hover {
+  border-color: rgba(155, 27, 48, 0.7);
+  color: #fff;
+}
+
+.archive-onboarding,
+.witness-mode {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.88);
+  padding: 1rem;
+  backdrop-filter: blur(12px);
+}
+
+.archive-onboarding.is-visible,
+.witness-mode.is-visible {
+  display: flex;
+}
+
+.archive-onboarding-panel {
+  width: min(46rem, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #090909;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7);
+  padding: 1.5rem;
+}
+
+.onboarding-topline {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.onboarding-kicker {
+  color: #9b1b30;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.archive-onboarding h2 {
+  margin-top: 0.45rem;
+  color: #eee8df;
+  font-family: "Playfair Display", serif;
+  font-size: 1.75rem;
+}
+
+.onboarding-close {
+  border: 0;
+  background: transparent;
+  color: #817b73;
+  font-size: 1.5rem;
+}
+
+.onboarding-close:hover {
+  color: #fff;
+}
+
+.onboarding-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 1.3rem 0;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.onboarding-item {
+  background: #0d0d0d;
+  padding: 1rem;
+}
+
+.onboarding-item strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #d4cdc3;
+  font-family: "Playfair Display", serif;
+  font-size: 0.95rem;
+}
+
+.onboarding-item span {
+  color: #7f7971;
+  font-size: 0.7rem;
+  line-height: 1.55;
+}
+
+.onboarding-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.onboarding-note {
+  color: #68635c;
+  font-size: 0.65rem;
+}
+
+.witness-panel {
+  width: min(47rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  background: #070707;
+  box-shadow: 0 35px 90px rgba(0, 0, 0, 0.75);
+}
+
+.witness-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.witness-header span {
+  color: #8f897f;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.witness-exit {
+  border: 0;
+  background: transparent;
+  color: #858078;
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.witness-exit:hover {
+  color: #fff;
+}
+
+.witness-content {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+}
+
+.witness-date {
+  color: #9b1b30;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.witness-content h2 {
+  margin: 0.9rem 0 1.1rem;
+  color: #f0ebe3;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.75rem, 5vw, 2.8rem);
+  line-height: 1.12;
+}
+
+.witness-summary {
+  max-width: 39rem;
+  color: #b1aaa0;
+  font-family: "Playfair Display", serif;
+  font-size: 1.02rem;
+  line-height: 1.8;
+}
+
+.witness-source {
+  margin-top: 1.5rem;
+  color: #716c65;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.witness-open-record {
+  margin-top: 1.1rem;
+  border: 0;
+  border-bottom: 1px solid rgba(201, 168, 76, 0.45);
+  background: transparent;
+  color: #9c958a;
+  padding: 0 0 0.3rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.witness-open-record:hover {
+  border-bottom-color: #c9a84c;
+  color: #fff;
+}
+
+.witness-controls {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.witness-controls button {
+  min-height: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #0d0d0d;
+  color: #9c958a;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.witness-controls button:hover {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.witness-position {
+  color: #625e58;
+  font-size: 0.62rem;
+  text-align: center;
+}
+
+.archive-orientation {
+  position: fixed;
+  right: 1rem;
+  top: 50%;
+  z-index: 1900;
+  display: none;
+  width: 7.5rem;
+  transform: translateY(-50%);
+}
+
+.archive-orientation-inner {
+  display: grid;
+  gap: 0.2rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  padding-right: 0.7rem;
+}
+
+.archive-orientation a {
+  display: block;
+  color: #5f5b55;
+  padding: 0.3rem 0;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-align: right;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: color 0.2s ease;
+}
+
+.archive-orientation a:hover,
+.archive-orientation a.is-active {
+  color: #d0c9bf;
+}
+
+.archive-orientation a.is-active::after {
+  content: "";
+  position: absolute;
+  right: -0.15rem;
+  width: 0.3rem;
+  height: 0.3rem;
+  margin-top: 0.27rem;
+  border-radius: 50%;
+  background: #c9a84c;
+}
+
+.archive-mobile-map {
+  position: fixed;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  z-index: 2300;
+  display: none;
+}
+
+.archive-mobile-map-button {
+  min-height: 2.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 8, 8, 0.94);
+  color: #9a948b;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+}
+
+.archive-mobile-map-menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.4rem);
+  display: none;
+  width: 11rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #090909;
+  padding: 0.35rem;
+}
+
+.archive-mobile-map.is-open .archive-mobile-map-menu {
+  display: grid;
+}
+
+.archive-mobile-map-menu a {
+  color: #908a82;
+  padding: 0.65rem 0.7rem;
+  font-size: 0.65rem;
+  text-decoration: none;
+}
+
+.archive-mobile-map-menu a:hover,
+.archive-mobile-map-menu a.is-active {
+  background: #111;
+  color: #fff;
+}
+
+body.archive-overlay-open {
+  overflow: hidden;
+}
+
+.research-packet-notepad {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 2400;
+  width: min(21rem, calc(100vw - 2rem));
+  overflow: hidden;
+  border: 1px solid rgba(201, 168, 76, 0.28);
+  background: rgba(8, 8, 8, 0.96);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.62);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.75rem);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  backdrop-filter: blur(16px);
+}
+
+.research-packet-notepad.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.research-packet-notepad-header {
+  min-height: 3.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0.9rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.research-packet-kicker {
+  display: block;
+  color: #9b1b30;
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.research-packet-notepad h2 {
+  margin-top: 0.15rem;
+  color: #e7e1d8;
+  font-family: "Playfair Display", serif;
+  font-size: 1rem;
+}
+
+.research-packet-notepad h2 span {
+  color: #8d877d;
+  font-family: Inter, sans-serif;
+  font-size: 0.65rem;
+}
+
+.research-packet-collapse {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  background: #0d0d0d;
+  color: #9c958a;
+  font-size: 1rem;
+}
+
+.research-packet-collapse:hover {
+  border-color: rgba(201, 168, 76, 0.5);
+  color: #fff;
+}
+
+.research-packet-notepad-content {
+  padding: 0.75rem;
+}
+
+.research-packet-notepad.is-collapsed .research-packet-notepad-content {
+  display: none;
+}
+
+.research-packet-controls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 0.65rem;
+}
+
+.research-packet-controls label {
+  color: #716c65;
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.research-packet-controls select {
+  min-height: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 0;
+  background: #0d0d0d;
+  color: #b8b2a8;
+  padding: 0.35rem 1.8rem 0.35rem 0.55rem;
+  font-size: 0.65rem;
+}
+
+.research-packet-notepad-list {
+  max-height: min(48vh, 24rem);
+  display: grid;
+  gap: 0.45rem;
+  overflow-y: auto;
+  padding-right: 0.15rem;
+  scrollbar-color: #413b34 transparent;
+  scrollbar-width: thin;
+}
+
+.research-packet-note {
+  border-left: 1px solid rgba(201, 168, 76, 0.48);
+  background: #0d0d0d;
+  padding: 0.7rem 0.75rem;
+}
+
+.research-packet-note-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  margin-bottom: 0.35rem;
+}
+
+.research-packet-note-meta span {
+  color: #68635c;
+  font-size: 0.54rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.research-packet-note button {
+  border: 0;
+  background: transparent;
+  color: #8d877d;
+  padding: 0;
+  font-size: 0.55rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.research-packet-note button:hover {
+  color: #fff;
+}
+
+.research-packet-citation {
+  color: #b8b2a8;
+  font-family: "Playfair Display", serif;
+  font-size: 0.72rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+}
+
+.research-packet-notepad-actions {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  margin-top: 0.65rem;
+}
+
+.research-packet-notepad-actions button {
+  min-height: 2.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #111;
+  color: #a9a298;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.research-packet-notepad-actions button:first-child {
+  border-color: rgba(139, 0, 0, 0.65);
+  background: #6f101c;
+  color: #fff;
+}
+
+.research-packet-notepad-actions button:hover {
+  filter: brightness(1.14);
+}
+
+/* The shared site shell sits at z-index 5000. Focused reading and creation
+   surfaces intentionally sit above it so their exit controls remain clear. */
+.story-sidebar {
+  z-index: 7000 !important;
+}
+
+#story-generator-backdrop {
+  z-index: 6900 !important;
+}
+
+@media (min-width: 1024px) {
+  .archive-pathways-shell,
+  #articles > .container {
+    padding-left: 5rem;
+  }
+}
+
+@media (min-width: 1180px) {
+  .archive-orientation {
+    display: block;
+  }
+
+  .archive-pathways-shell,
+  #articles > .container {
+    padding-right: 9rem;
+  }
+}
+
+@media (max-width: 1179px) {
+  .archive-mobile-map {
+    display: block;
+  }
+
+  body.archive-filters-open .archive-mobile-map {
+    display: none;
+  }
+}
+
+@media (max-width: 800px) {
+  .archive-methodology-grid,
+  .claim-records,
+  .onboarding-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .archive-pathways-heading,
+  .claim-layout,
+  .thread-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .archive-pathways-heading {
+    align-items: start;
+  }
+
+  .archive-pathways-heading-actions {
+    width: 100%;
+  }
+
+  .archive-pathways-heading-actions button {
+    flex: 1;
+  }
+
+  .pathway-selector {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pathway-selector-label {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .research-packet-notepad {
+    right: 0.65rem;
+    bottom: 4.1rem;
+    width: min(20rem, calc(100vw - 1.3rem));
+  }
+
+  .research-packet-notepad-list {
+    max-height: 38vh;
+  }
+
+  .archive-methodology {
+    margin-top: -1.5rem;
+    margin-bottom: 2.25rem;
+  }
+
+  .archive-methodology summary {
+    min-height: 2.9rem;
+    font-size: 0.58rem;
+  }
+
+  .archive-pathways-shell {
+    padding: 2.5rem 1rem;
+  }
+
+  .archive-pathway-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .archive-pathway-tab {
+    min-height: 2.85rem;
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .archive-pathway-tab:last-child {
+    border-bottom: 0;
+  }
+
+  .archive-pathway-tab[aria-selected="true"] {
+    box-shadow: inset 2px 0 #9b1b30;
+  }
+
+  .archive-pathway-panel {
+    min-height: 0;
+    padding: 1rem;
+  }
+
+  .pathway-selector {
+    grid-template-columns: 1fr;
+  }
+
+  .archive-toolbar-heading {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .archive-toolbar-heading-actions,
+  .archive-toolbar-heading-actions button {
+    width: 100%;
+  }
+
+  .filter-panel-intro {
+    display: block;
+  }
+
+  .filter-panel-intro p {
+    margin-top: 0.45rem;
+  }
+
+  .active-filter-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .archive-onboarding-panel {
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+    padding: 1.1rem;
+  }
+
+  .onboarding-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .witness-controls {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .witness-position {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .claim-record,
+  .thread-record {
+    transition: none;
+  }
+}

--- a/assets/site-shell.css
+++ b/assets/site-shell.css
@@ -419,6 +419,15 @@ body.site-shell-pad {
 }
 
 @media (max-width: 800px) {
+  body.site-shell-pad {
+    padding-top: 54px;
+  }
+
+  .site-shell-header,
+  .site-shell-mobile-top {
+    height: 54px;
+  }
+
   .site-shell-nav {
     display: none;
   }
@@ -432,6 +441,7 @@ body.site-shell-pad {
 
   .site-shell-mobile-button {
     display: inline-flex;
+    height: 38px;
     min-height: 44px;
   }
 

--- a/assets/site-shell.js
+++ b/assets/site-shell.js
@@ -41,7 +41,8 @@
                 <a href="${home}/#quotes">Quotes & Resources</a>
                 <a href="${home}/blog">Voices</a>
                 <a href="${home}/events">Events</a>
-                <a href="${home}/#faq">FAQ</a>
+                <a href="${home}/about">About</a>
+                <a href="${home}/about#faq">FAQ</a>
               </span>
             </span>
           </span>
@@ -66,6 +67,7 @@
         <a href="${home}/#victims">Victims</a>
         <a href="${home}/events">Events</a>
         <a href="${home}/blog">Voices</a>
+        <a href="${home}/about">About</a>
         <a href="${home}/collab" class="site-shell-submit">Submit Evidence</a>
       </nav>
     </div>`;
@@ -109,8 +111,8 @@
               <ul>
                 <li><a href="${home}/#quotes">Quotes</a></li>
                 <li><a href="${home}/blog">Voices</a></li>
+                <li><a href="${home}/about">About & FAQ</a></li>
                 <li><a href="https://data.techforpalestine.org/api/v2/killed-in-gaza.min.json" target="_blank" rel="noopener noreferrer">Raw Data</a></li>
-                <li><a href="${home}/blog">Blog</a></li>
               </ul>
             </div>
             <div>

--- a/assets/story-generator.js
+++ b/assets/story-generator.js
@@ -1,0 +1,250 @@
+(function () {
+  const root = document.getElementById("story-generator-root");
+  if (!root) return;
+
+  root.innerHTML = `
+    <div id="story-generator-backdrop" class="fixed inset-0 bg-black/90 backdrop-blur-sm z-[2900] hidden" aria-hidden="true"></div>
+    <aside id="story-generator-sidebar" class="story-sidebar bg-[#0a0a0a] border-l border-[#222]" aria-hidden="true" aria-labelledby="story-generator-title">
+      <button type="button" class="story-mobile-floating-close" data-story-close aria-label="Exit Story Creator">
+        <span>Exit</span>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+      </button>
+      <div class="sticky top-0 z-10 bg-[#0a0a0a]/95 border-b border-[#222] px-6 py-4 flex justify-between items-center">
+        <h2 id="story-generator-title" class="text-lg font-serif font-bold text-white tracking-wide">Story Creator</h2>
+        <button type="button" class="story-close-button" data-story-close aria-label="Close Story Creator">
+          <span class="story-close-label">Close</span>
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+        </button>
+      </div>
+      <div class="p-6 space-y-8 overflow-y-auto">
+        <div class="space-y-3">
+          <label class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Preview</label>
+          <div class="w-full aspect-square bg-black border border-[#222] rounded-sm overflow-hidden">
+            <canvas id="story-generator-canvas" class="w-full h-full object-contain"></canvas>
+          </div>
+        </div>
+        <div class="space-y-6">
+          <button type="button" id="story-generate-daily" class="w-full bg-[#151515] border border-[#222] hover:border-[#444] text-white text-xs font-bold py-3 uppercase tracking-widest transition">
+            Generate daily update
+          </button>
+          <div class="space-y-2">
+            <label for="story-image-url" class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Image URL</label>
+            <input id="story-image-url" type="url" class="w-full bg-[#050505] border border-[#222] rounded-sm px-4 py-3 text-gray-300 text-xs focus:border-gray-500 outline-none transition">
+          </div>
+          <div class="space-y-2">
+            <label for="story-headline" class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Headline</label>
+            <textarea id="story-headline" rows="3" class="w-full bg-[#050505] border border-[#222] rounded-sm px-4 py-3 text-gray-300 text-xs focus:border-gray-500 outline-none transition"></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="story-summary" class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Summary</label>
+            <textarea id="story-summary" rows="5" class="w-full bg-[#050505] border border-[#222] rounded-sm px-4 py-3 text-gray-300 text-xs focus:border-gray-500 outline-none transition"></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="story-date" class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Date</label>
+            <input id="story-date" type="date" class="w-full bg-[#050505] border border-[#222] rounded-sm px-4 py-3 text-gray-300 text-xs focus:border-gray-500 outline-none transition">
+          </div>
+        </div>
+        <div class="pt-4 sticky bottom-0 bg-[#0a0a0a] pb-6">
+          <button type="button" id="story-share" class="w-full bg-[#8B0000] hover:bg-[#660000] text-white font-bold py-4 rounded-sm uppercase tracking-widest text-xs transition">Share or download story</button>
+          <button type="button" class="story-mobile-exit w-full mt-3 border border-[#333] bg-[#111] hover:bg-[#171717] text-gray-300 hover:text-white font-bold py-3 rounded-sm uppercase tracking-widest text-[10px] transition" data-story-close>Close Story Creator</button>
+        </div>
+      </div>
+    </aside>
+  `;
+
+  const backdrop = document.getElementById("story-generator-backdrop");
+  const sidebar = document.getElementById("story-generator-sidebar");
+  const canvas = document.getElementById("story-generator-canvas");
+  const imageInput = document.getElementById("story-image-url");
+  const titleInput = document.getElementById("story-headline");
+  const summaryInput = document.getElementById("story-summary");
+  const dateInput = document.getElementById("story-date");
+  const context = canvas.getContext("2d");
+  let drawSequence = 0;
+
+  function close() {
+    sidebar.classList.remove("open");
+    sidebar.setAttribute("aria-hidden", "true");
+    backdrop.classList.add("hidden");
+    backdrop.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("archive-overlay-open");
+  }
+
+  function open(detail) {
+    titleInput.value = detail.title || "";
+    summaryInput.value = detail.summary || "";
+    dateInput.value = detail.date || new Date().toISOString().slice(0, 10);
+    imageInput.value = detail.imageUrl || "";
+    sidebar.classList.add("open");
+    sidebar.setAttribute("aria-hidden", "false");
+    backdrop.classList.remove("hidden");
+    backdrop.setAttribute("aria-hidden", "false");
+    document.body.classList.add("archive-overlay-open");
+    draw();
+    sidebar.querySelector("[data-story-close]")?.focus();
+  }
+
+  function ordinal(day) {
+    const remainder = day % 100;
+    if (remainder >= 11 && remainder <= 13) return `${day}th`;
+    if (day % 10 === 1) return `${day}st`;
+    if (day % 10 === 2) return `${day}nd`;
+    if (day % 10 === 3) return `${day}rd`;
+    return `${day}th`;
+  }
+
+  function setDailyUpdate() {
+    const now = new Date();
+    const day = now.toLocaleDateString("en-US", { weekday: "long" });
+    const month = now.toLocaleDateString("en-US", { month: "long" });
+    imageInput.value = "";
+    titleInput.value = `Updates — ${day}, ${month} ${ordinal(now.getDate())}`;
+    summaryInput.value = "Recent records from Gaza and Palestine, collected to preserve the public record and resist erasure.";
+    dateInput.value = now.toISOString().slice(0, 10);
+    draw();
+  }
+
+  function loadImage(url) {
+    return new Promise((resolve, reject) => {
+      if (!url) {
+        reject(new Error("No image"));
+        return;
+      }
+      const image = new Image();
+      image.crossOrigin = "anonymous";
+      image.onload = () => resolve(image);
+      image.onerror = () => {
+        const proxy = new Image();
+        proxy.crossOrigin = "anonymous";
+        proxy.onload = () => resolve(proxy);
+        proxy.onerror = () => reject(new Error("Image unavailable"));
+        proxy.src = `https://wsrv.nl/?url=${encodeURIComponent(url)}&w=2000&fit=cover`;
+      };
+      image.src = url;
+    });
+  }
+
+  function wrapText(text, x, y, maxWidth, lineHeight, maxLines) {
+    const words = String(text || "").split(/\s+/).filter(Boolean);
+    let line = "";
+    let currentY = y;
+    let lines = 0;
+    for (let index = 0; index < words.length; index += 1) {
+      const candidate = `${line}${words[index]} `;
+      if (context.measureText(candidate).width > maxWidth && line && lines < maxLines - 1) {
+        context.fillText(line.trim(), x, currentY);
+        line = `${words[index]} `;
+        currentY += lineHeight;
+        lines += 1;
+      } else {
+        line = candidate;
+      }
+    }
+    if (line && lines < maxLines) context.fillText(line.trim(), x, currentY);
+    return currentY + lineHeight;
+  }
+
+  async function draw() {
+    const sequence = ++drawSequence;
+    const size = 2000;
+    canvas.width = size;
+    canvas.height = size;
+    context.fillStyle = "#0a0a0a";
+    context.fillRect(0, 0, size, size);
+
+    try {
+      const image = await loadImage(imageInput.value.trim());
+      if (sequence !== drawSequence) return;
+      const imageAspect = image.width / image.height;
+      let sx = 0;
+      let sy = 0;
+      let sw = image.width;
+      let sh = image.height;
+      if (imageAspect > 1) {
+        sw = image.height;
+        sx = (image.width - sw) / 2;
+      } else {
+        sh = image.width;
+        sy = (image.height - sh) / 2;
+      }
+      context.drawImage(image, sx, sy, sw, sh, 0, 0, size, size);
+    } catch (error) {
+      context.fillStyle = "#151515";
+      context.fillRect(0, 0, size, size);
+    }
+
+    if (sequence !== drawSequence) return;
+    const overlay = context.createLinearGradient(0, 0, 0, size);
+    overlay.addColorStop(0, "rgba(0,0,0,0.28)");
+    overlay.addColorStop(0.58, "rgba(0,0,0,0.82)");
+    overlay.addColorStop(1, "rgba(0,0,0,1)");
+    context.fillStyle = overlay;
+    context.fillRect(0, 0, size, size);
+
+    context.textAlign = "left";
+    context.fillStyle = "#ffffff";
+    context.font = '700 40px "Playfair Display", Georgia, serif';
+    context.fillText("ECHOES OF GAZA", 100, 110);
+
+    const startX = 100;
+    const textX = 140;
+    const maxWidth = size - 260;
+    let currentY = 990;
+    context.fillStyle = "#8b0000";
+    context.fillRect(startX, currentY, 14, 430);
+
+    context.fillStyle = "#c9a84c";
+    context.font = '700 30px Inter, Arial, sans-serif';
+    context.fillText(`${(dateInput.value || "").toUpperCase()} / ARCHIVE`, textX, currentY + 30);
+
+    currentY += 120;
+    context.fillStyle = "#ffffff";
+    context.font = '700 80px "Playfair Display", Georgia, serif';
+    currentY = wrapText(titleInput.value, textX, currentY, maxWidth, 98, 5);
+
+    currentY += 25;
+    context.fillStyle = "#c8c2b8";
+    context.font = "400 42px Inter, Arial, sans-serif";
+    wrapText(summaryInput.value, textX, currentY, maxWidth, 65, 6);
+
+    context.fillStyle = "rgba(255,255,255,0.45)";
+    context.font = "600 25px Inter, Arial, sans-serif";
+    context.textAlign = "right";
+    context.fillText("ECHOESOFGAZA.ORG", size - 100, size - 80);
+  }
+
+  async function shareOrDownload() {
+    draw();
+    await new Promise(resolve => window.setTimeout(resolve, 80));
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, "image/png"));
+    if (!blob) return;
+    const file = new File([blob], "echoes-of-gaza-story.png", { type: "image/png" });
+    if (navigator.canShare?.({ files: [file] })) {
+      try {
+        await navigator.share({
+          files: [file],
+          title: "Echoes of Gaza record",
+          text: "A record from echoesofgaza.org"
+        });
+        return;
+      } catch (error) {
+        if (error?.name === "AbortError") return;
+      }
+    }
+    const link = document.createElement("a");
+    link.download = file.name;
+    link.href = URL.createObjectURL(blob);
+    link.click();
+    window.setTimeout(() => URL.revokeObjectURL(link.href), 1000);
+  }
+
+  window.addEventListener("openStoryGenerator", event => open(event.detail || {}));
+  backdrop.addEventListener("click", close);
+  root.querySelectorAll("[data-story-close]").forEach(button => button.addEventListener("click", close));
+  [imageInput, titleInput, summaryInput, dateInput].forEach(input => input.addEventListener("input", draw));
+  document.getElementById("story-generate-daily").addEventListener("click", setDailyUpdate);
+  document.getElementById("story-share").addEventListener("click", shareOrDownload);
+  document.addEventListener("keydown", event => {
+    if (event.key === "Escape" && sidebar.classList.contains("open")) close();
+  });
+})();

--- a/collab.html
+++ b/collab.html
@@ -405,7 +405,7 @@
             border-color: #4d1b1b;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="min-h-screen flex flex-col">
 
@@ -1984,6 +1984,6 @@
           }
         });
       </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/content_calendar.html
+++ b/content_calendar.html
@@ -54,7 +54,7 @@
             overflow: hidden;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="min-h-screen bg-[#FDFBF7] font-sans text-stone-900 selection:bg-emerald-100 selection:text-emerald-900 pb-16">
 
@@ -641,6 +641,6 @@ async function apiDeletePost(id) {
         loadData();
         
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/data/articles.json
+++ b/data/articles.json
@@ -1,5 +1,65 @@
 [
   {
+    "date": "2026-02-26",
+    "title": "Domicide: Mass destruction of housing and civilian infrastructure in Gaza, Myanmar, Sudan and Ukraine",
+    "summary": "A UN Special Rapporteur report documenting large-scale destruction of housing and civilian infrastructure, including estimates that at least 92 percent of Gaza's housing units were damaged or destroyed between October 2023 and October 2025.",
+    "link": "https://www.ohchr.org/en/documents/thematic-reports/ahrc6143add3-domicide-mass-destruction-housing-and-civilian",
+    "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Flag_of_the_United_Nations.svg/1200px-Flag_of_the_United_Nations.svg.png",
+    "category": "Destruction",
+    "categories": [
+      "Destruction",
+      "Forced Displacement",
+      "Human Rights"
+    ],
+    "categoryColor": "#B5EAD7",
+    "source": "OHCHR",
+    "author": "Special Rapporteur on the right to adequate housing",
+    "authors": [
+      "Special Rapporteur on the right to adequate housing"
+    ],
+    "documentType": "Report"
+  },
+  {
+    "date": "2026-02-25",
+    "title": "Record 129 press members killed in 2025; Israel responsible for 2/3 of deaths",
+    "summary": "The Committee to Protect Journalists' annual report found that journalist killings reached a record high in 2025, with Israel responsible for two-thirds of the deaths and the majority of those killed being Palestinian journalists.",
+    "link": "https://cpj.org/special-reports/record-129-press-members-killed-in-2025-israel-responsible-for-2-of-3-of-deaths/",
+    "imageUrl": "https://cpj.org/wp-content/uploads/2026/02/AFP__20250825__72DU89J__v5__HighRes__CorrectionPalestinianIsraelConflict.jpg?fit=4096,4096&strip=all&quality=80",
+    "category": "Press Freedom",
+    "categories": [
+      "Press Freedom",
+      "Media",
+      "Accountability"
+    ],
+    "categoryColor": "#FFB7B2",
+    "source": "Committee to Protect Journalists",
+    "author": "Committee to Protect Journalists",
+    "authors": [
+      "Committee to Protect Journalists"
+    ],
+    "documentType": "Report"
+  },
+  {
+    "date": "2025-09-18",
+    "title": "Humanitarian Situation Update #323 | Gaza Strip",
+    "summary": "OCHA reported more than 246,800 displacement movements since mid-August, severe overcrowding, families sleeping in the open or in makeshift shelters, and shelter materials reaching less than one percent of estimated need.",
+    "link": "https://www.ochaopt.org/content/humanitarian-situation-update-323-gaza-strip",
+    "imageUrl": "https://disasterdisplacement.org/wp-content/uploads/2021/02/OCHA_logo.jpg",
+    "category": "Forced Displacement",
+    "categories": [
+      "Forced Displacement",
+      "Humanitarian Crisis",
+      "Living Conditions"
+    ],
+    "categoryColor": "#FF6B6B",
+    "source": "OCHA",
+    "author": "United Nations Office for the Coordination of Humanitarian Affairs",
+    "authors": [
+      "United Nations Office for the Coordination of Humanitarian Affairs"
+    ],
+    "documentType": "Report"
+  },
+  {
     "date": "2026-06-13",
     "title": "This Week in Palestine: Israel Kills 8-Year-Old Schoolboy and 15-Year-Old Fisherman Just Days After Murdering 7-Month-Old Baby",
     "summary": "Zeteo's weekly round-up of the stories you may have missed out of occupied Gaza and the West Bank, as Israel continues its genocidal war and apartheid policies.",

--- a/echoesindayton.html
+++ b/echoesindayton.html
@@ -21,7 +21,7 @@
         .font-serif { font-family: 'Playfair Display', serif; }
         .font-sans { font-family: 'Inter', sans-serif; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="min-h-screen bg-[#0B0B0B] text-[#EDEDED] selection:bg-[#8C0D0D] selection:text-[#EDEDED]">
 
@@ -276,6 +276,6 @@
             });
         });
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -156,7 +156,7 @@
             scroll-margin-top: 6rem;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="flex flex-col min-h-screen">
 
@@ -552,6 +552,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -141,16 +141,12 @@
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
     
-    <!-- REACT & BABEL FOR STORY GENERATOR -->
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Font Links -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./assets/site-tokens.css?v=design-1">
+    <link rel="stylesheet" href="./assets/archive-experience.css?v=2">
     <style>
         /* Define new color variables */
         :root {
@@ -550,7 +546,18 @@
                 border-radius: 999px;
                 box-shadow: 0 16px 38px rgba(0, 0, 0, 0.38);
                 backdrop-filter: blur(12px);
-                transform: translateY(-50%);
+                opacity: 0;
+                pointer-events: none;
+                visibility: hidden;
+                transform: translate(-0.5rem, -50%);
+                transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+            }
+
+            .desktop-display-zoom.is-context-visible {
+                opacity: 1;
+                pointer-events: auto;
+                visibility: visible;
+                transform: translate(0, -50%);
             }
 
             .desktop-display-zoom span {
@@ -1150,65 +1157,6 @@
                 padding-top: 1rem;
             }
 
-            #research-packet-panel {
-                padding: 0.9rem;
-                margin-bottom: 1.15rem;
-            }
-
-            .research-packet-header {
-                gap: 0.9rem;
-            }
-
-            #research-packet-panel h3 {
-                font-size: 1.35rem;
-                line-height: 1.1;
-                margin-top: 0.45rem;
-            }
-
-            #research-packet-summary {
-                font-size: 0.82rem;
-                line-height: 1.45;
-                margin-top: 0.45rem;
-            }
-
-            .research-packet-actions {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 0.55rem;
-                width: 100%;
-                align-items: stretch;
-            }
-
-            .research-style-control {
-                display: grid;
-                grid-column: 1 / -1;
-                grid-template-columns: auto minmax(0, 1fr);
-                align-items: center;
-                gap: 0.55rem;
-                width: 100%;
-                border: 1px solid rgba(255, 255, 255, 0.06);
-                background: #0b0b0b;
-                padding: 0.45rem 0.55rem;
-            }
-
-            #research-citation-style {
-                width: 100%;
-                padding: 0.55rem 0.7rem;
-                min-height: 2.35rem;
-            }
-
-            #copy-research-packet,
-            #clear-research-packet {
-                width: 100%;
-                min-height: 2.45rem;
-                padding: 0.65rem 0.7rem;
-                font-size: 0.62rem;
-            }
-
-            #research-packet-list {
-                margin-top: 0.9rem;
-            }
-
             .archive-display-toolbar {
                 display: block;
                 margin-bottom: 0.85rem;
@@ -1715,7 +1663,7 @@
             background: rgba(153, 27, 27, 0.05) !important;
         }
 
-        /* Story Generator Styles (React Component) */
+        /* Story Generator Styles */
         .story-sidebar {
             position: fixed; top: 0; right: 0; width: 100%; max-width: 480px; height: 100%;
             background: #080808; border-left: 1px solid #222; z-index: 3000;
@@ -1851,7 +1799,7 @@
             }
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">
@@ -1914,7 +1862,8 @@
                              <a href="https://echoesofgaza.org/podcast" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Podcast</a>
                                 <a href="#quotes" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Quotes & Resources</a>
                                 <a href="https://echoesofgaza.org/events" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Events</a>
-                                <a href="#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
+                                <a href="./about.html" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">About</a>
+                                <a href="./about.html#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
                                 <a href="https://echoesofgaza.org/toolkit" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Toolkit</a>
                 
                             </div>
@@ -1953,7 +1902,7 @@
             <a href="#quotes" class="mobile-nav-link text-gray-400 hover:text-white transition">Resources</a>
             <a href="https://echoesofgaza.org/events" class="mobile-nav-link text-gray-400 hover:text-white transition">Events</a>
             <a href="https://echoesofgaza.org/podcast"  class="mobile-nav-link text-gray-400 hover:text-white transition">EOG Podcast</a>
-            <a href="#faq" class="mobile-nav-link text-gray-400 hover:text-white transition">FAQ</a>
+            <a href="./about.html" class="mobile-nav-link text-gray-400 hover:text-white transition">About</a>
             <a href="https://echoesofgaza.org/collab" class="mobile-nav-link btn-primary px-8 py-3 rounded text-sm uppercase">Submit Evidence</a>
         </nav>
     </div>
@@ -1968,7 +1917,7 @@
 
     <!-- MAIN CONTENT -->
     <main>
-        <section class="hero-section pt-32 pb-12">
+        <section id="top" class="hero-section pt-32 pb-12">
             <video class="hero-bg-video" autoplay muted loop playsinline webkit-playsinline preload="auto" aria-hidden="true">
                 <source src="https://pub-3592c0f33d62473e96882cebf2720dba.r2.dev/EoG%20-%20Background.mp4" type="video/mp4" />
             </video>
@@ -2002,6 +1951,34 @@
                             <div class="text-xs text-gray-500 uppercase tracking-[0.15em]">Kill Zone</div>
                         </button>
                     </div>
+
+                    <details class="archive-methodology">
+                        <summary>How these figures are defined</summary>
+                        <div class="archive-methodology-body">
+                            <p class="archive-methodology-intro">
+                                These figures provide context, but they do not measure the same thing. Each should be read with its source, scope, and uncertainty intact.
+                            </p>
+                            <div class="archive-methodology-grid">
+                                <div class="archive-methodology-item">
+                                    <strong>Estimated casualties</strong>
+                                    <span>A broad external estimate linked above. It is not presented as the official confirmed fatality count and may include indirect, missing, or projected losses.</span>
+                                </div>
+                                <div class="archive-methodology-item">
+                                    <strong>Journalists</strong>
+                                    <span>A source-maintained count from Stop Murdering Journalists. Inclusion criteria and updates are controlled by that source.</span>
+                                </div>
+                                <div class="archive-methodology-item">
+                                    <strong>Days</strong>
+                                    <span>Calculated automatically from October 7, 2023 through the visitor’s current date.</span>
+                                </div>
+                                <div class="archive-methodology-item">
+                                    <strong>Kill zone</strong>
+                                    <span>A territorial-control indicator drawn from linked reporting. It describes land affected or controlled, not a percentage of casualties.</span>
+                                </div>
+                            </div>
+                            <p class="archive-methodology-reviewed">Methodology note reviewed June 18, 2026 · Open each figure to inspect its source</p>
+                        </div>
+                    </details>
 
                     <div class="hero-quote mb-20 text-center opacity-60">
                         <p class="text-sm font-serif italic text-gray-400">"We record so the world cannot say they did not know."</p>
@@ -2121,14 +2098,55 @@
             </div>
         </section>
 
+        <!-- Guided research pathways -->
+        <section id="research-pathways" class="archive-pathways" aria-labelledby="research-pathways-title">
+            <div class="archive-pathways-shell">
+                <div class="archive-pathways-heading">
+                    <div>
+                        <span class="archive-pathways-kicker">Ways into the record</span>
+                        <h2 id="research-pathways-title">Follow evidence without losing its context</h2>
+                        <p>Examine a public claim or trace a subject through time without losing the source sequence. These views organize existing records; they do not replace the sources.</p>
+                    </div>
+                    <div class="archive-pathways-heading-actions">
+                        <button type="button" id="open-witness-mode" class="witness-entry-button">Enter Witness Mode</button>
+                    </div>
+                </div>
+
+                <div class="archive-pathway-tabs" role="tablist" aria-label="Research pathways">
+                    <button type="button" class="archive-pathway-tab" id="claim-tab" role="tab" aria-selected="true" aria-controls="claim-panel" data-pathway-tab="claim-panel">Examine a claim</button>
+                    <button type="button" class="archive-pathway-tab" id="thread-tab" role="tab" aria-selected="false" aria-controls="thread-panel" data-pathway-tab="thread-panel">Follow a thread</button>
+                </div>
+
+                <div id="claim-panel" class="archive-pathway-panel" role="tabpanel" aria-labelledby="claim-tab">
+                    <div class="claim-layout">
+                        <div id="claim-selector" class="pathway-selector" aria-label="Claims to examine"></div>
+                        <div id="claim-result" aria-live="polite"></div>
+                    </div>
+                </div>
+
+                <div id="thread-panel" class="archive-pathway-panel" role="tabpanel" aria-labelledby="thread-tab" hidden>
+                    <div class="thread-layout">
+                        <div id="thread-selector" class="pathway-selector" aria-label="Threads to follow"></div>
+                        <div id="thread-result" aria-live="polite"></div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
         <!-- Archive Section -->
         <section id="articles" class="py-12">
             <div class="container mx-auto px-6">
-                <h2 class="text-3xl font-serif font-bold mb-12 text-white/90">Documentary Archive</h2>
+                <div class="archive-toolbar-heading">
+                    <h2 class="text-3xl font-serif font-bold text-white/90">Documentary Archive</h2>
+                    <div class="archive-toolbar-heading-actions">
+                        <button type="button" id="open-archive-guide" class="archive-help-button">How to use the archive</button>
+                    </div>
+                </div>
                 <div class="flex flex-col md:flex-row justify-between items-center mb-10 gap-6">
                     <div class="article-search-row flex w-full md:flex-1 space-x-4">
                         <div class="relative flex-1">
-                            <input type="text" id="article-search" class="search-modern w-full pl-10 pr-4 py-2 text-sm outline-none" placeholder="Search archive...">
+                            <input type="text" id="article-search" class="search-modern w-full pl-10 pr-4 py-2 text-sm outline-none" placeholder="Search titles, summaries, sources, or topics">
                             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                                 <svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
                             </div>
@@ -2137,12 +2155,25 @@
                             Random
                         </button>
                         <div id="sort-controls" class="flex items-center flex-shrink-0">
-                            <button id="toggle-filter-btn" class="filter-chip text-xs uppercase tracking-wider font-medium py-2 px-4">Filters</button>
+                            <button id="toggle-filter-btn" class="filter-chip text-xs uppercase tracking-wider font-medium py-2 px-4" aria-expanded="false" aria-controls="filter-controls">
+                                Filters <span id="filter-count-badge" class="filter-count-badge" hidden>0</span>
+                            </button>
                         </div>
                     </div>
                 </div>
+
+                <div id="active-filter-strip" class="active-filter-strip" aria-live="polite">
+                    <span class="active-filter-label">Filtering by</span>
+                    <div id="active-filter-chips" class="active-filter-chips"></div>
+                </div>
                 
                 <div id="filter-controls" class="mb-12 p-8 border border-white/5 bg-[#0a0a0a] hidden">
+                    <div class="filter-panel-intro">
+                        <div>
+                            <h3>Narrow the documentary record</h3>
+                            <p>Select as much or as little as you need. Results combine your search, dates, topics, sources, authors, and document types.</p>
+                        </div>
+                    </div>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-8">
                         <div>
                             <h4 class="font-serif text-white/80 mb-4 border-b border-white/5 pb-2">Sort By</h4>
@@ -2186,33 +2217,9 @@
                         </div>
                     </div>
                     <div class="mt-8 pt-6 border-t border-white/5 flex items-center gap-4">
-                        <button id="filter-button" class="btn-primary text-xs uppercase tracking-wider px-6 py-2 rounded">Apply</button>
-                        <button id="clear-button" class="text-xs text-gray-500 hover:text-white uppercase tracking-wider transition">Clear</button>
+                        <button id="filter-button" class="btn-primary text-xs uppercase tracking-wider px-6 py-2 rounded">Show results</button>
+                        <button id="clear-button" class="text-xs text-gray-500 hover:text-white uppercase tracking-wider transition">Reset filters</button>
                     </div>
-                </div>
-
-                <div id="research-packet-panel" class="research-tool-card p-5 md:p-6 mb-10">
-                    <div class="research-packet-header flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-                        <div>
-                            <span class="text-[10px] text-[#8B0000] uppercase tracking-[0.2em] font-bold">Research Packet</span>
-                            <h3 class="text-xl font-serif text-white/90 mt-2">Saved Articles</h3>
-                            <p id="research-packet-summary" class="text-sm text-gray-500 mt-2">No articles saved yet.</p>
-                        </div>
-                        <div id="research-packet-actions" class="research-packet-actions hidden flex flex-wrap gap-2 items-center">
-                            <div class="research-style-control">
-                                <label for="research-citation-style" class="text-[10px] text-gray-600 uppercase tracking-widest">Style</label>
-                                <select id="research-citation-style" class="search-modern px-3 py-3 text-xs uppercase tracking-wider">
-                                    <option value="plain">Plain</option>
-                                    <option value="mla">MLA</option>
-                                    <option value="apa">APA</option>
-                                    <option value="chicago">Chicago</option>
-                                </select>
-                            </div>
-                            <button id="copy-research-packet" class="btn-primary px-5 py-3 rounded-sm text-xs uppercase tracking-widest">Copy Citations</button>
-                            <button id="clear-research-packet" class="btn-secondary px-5 py-3 rounded-sm text-xs uppercase tracking-widest">Clear Packet</button>
-                        </div>
-                    </div>
-                    <div id="research-packet-list" class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-3"></div>
                 </div>
 
                 <div class="archive-display-toolbar">
@@ -2447,51 +2454,6 @@
             </div>
         </section>
 
-        <!-- FAQ Section -->
-        <section id="faq" class="py-24 bg-[#080808] border-t border-white/5">
-            <div class="container mx-auto px-6">
-                <h3 class="text-2xl font-serif font-bold text-center mb-16 mx-auto text-white/90">Frequently Asked Questions</h3>
-                <div class="max-w-3xl mx-auto space-y-6">
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">What is Echoes of Gaza?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">Echoes of Gaza is a digital historical archive dedicated to documenting the ongoing occupation, displacement, and genocide of the Palestinian people. It serves as a meticulously curated and publicly accessible repository of verified articles, reports, and media evidence, built to resist erasure and preserve truth.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">Why was this project created?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">Echoes of Gaza was born from the recognition that history is too often written by those in power, erasing the voices and suffering of the oppressed. The project exists to create a permanent record of events in Gaza and across Palestine, one that cannot be rewritten or denied.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">What is the goal of Echoes of Gaza?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">The archive exists to preserve evidence, promote accountability, and humanize the Palestinian struggle. It provides researchers, journalists, and the public with verifiable documentation that exposes patterns of occupation, displacement, and systemic injustice.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">How is the archive maintained?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">The archive is updated daily. Each entry is carefully verified and cataloged with details such as title, author, publication date, and source. The aim is to ensure accuracy, transparency, and reliability for those using the collection for research, reporting, or advocacy.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">How does Echoes of Gaza promote accountability?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">By creating a centralized and timestamped record of events, the archive makes it impossible for atrocities to be hidden or denied. It provides an evidentiary foundation for journalists, human rights investigators, and legal experts seeking to document war crimes and systemic abuse.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">How does the project address systemic prejudice and racism?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">Echoes of Gaza reveals how racism, dehumanization, and colonial bias shape global responses to Palestinian suffering. By placing daily atrocities alongside decades of political betrayal, media distortion, and ignored international law, the archive shows that what is happening in Gaza is not an isolated tragedy, but the result of a broader system of racialized injustice.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">Who is the archive for?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">It is intended for journalists, educators, researchers, students, and advocates seeking an accurate and human-centered account of what is happening in Gaza. Above all, it is for anyone committed to truth, justice, and memory.</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">Can I use the materials for research or media?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">Yes. All materials are freely available for educational, journalistic, and humanitarian use. Please cite the archive as: Echoes of Gaza - A Digital Historical Record (echoesofgaza.org)</p>
-                    </div>
-                    <div class="card-modern p-8 rounded-sm">
-                        <h4 class="font-serif font-bold text-lg text-white mb-3">Why is this important now?</h4>
-                        <p class="text-gray-400 text-sm leading-relaxed">Because silence and distortion are weapons. When records disappear, justice becomes impossible. By preserving evidence and testimony in real time, Echoes of Gaza ensures that the historical record remains intact, and that the truth endures long after headlines fade.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-        
     </main>
 
     <!-- Footer -->
@@ -2506,7 +2468,7 @@
             </div>
             <div class="grid grid-cols-2 sm:grid-cols-3 gap-10 md:w-2/3">
                 <div><h4 class="text-white/80 mb-6 text-xs uppercase tracking-widest">Archive</h4><ul class="space-y-3 text-xs text-gray-500"><li><a href="#articles" class="hover:text-white transition">Articles</a></li><li><a href="#victims" class="hover:text-white transition">Martyrs</a></li></ul></div>
-                <div><h4 class="text-white/80 mb-6 text-xs uppercase tracking-widest">Resources</h4><ul class="space-y-3 text-xs text-gray-500"><li><a href="#quotes" class="hover:text-white transition">Quotes</a></li><li><a href="https://data.techforpalestine.org/api/v2/killed-in-gaza.min.json" target="_blank" class="hover:text-white transition">Raw Data</a></li></ul></div>
+                <div><h4 class="text-white/80 mb-6 text-xs uppercase tracking-widest">Resources</h4><ul class="space-y-3 text-xs text-gray-500"><li><a href="#quotes" class="hover:text-white transition">Quotes</a></li><li><a href="./about.html" class="hover:text-white transition">About & FAQ</a></li><li><a href="https://data.techforpalestine.org/api/v2/killed-in-gaza.min.json" target="_blank" class="hover:text-white transition">Raw Data</a></li></ul></div>
                 <div><h4 class="text-white/80 mb-6 text-xs uppercase tracking-widest">Support</h4><div class="flex flex-col space-y-3"><a href="https://buymeacoffee.com/echoesofgaza" target="_blank" class="text-xs text-gray-500 hover:text-white transition">Donate</a><a href="https://www.patreon.com/c/EchoesofGaza" target="_blank" class="text-xs text-[#8B0000] hover:text-red-400 transition">Monthly Support</a></div></div>
             </div>
         </div>
@@ -2571,8 +2533,110 @@
     </div>
 
 
-    <!-- REACT ROOT FOR STORY GENERATOR -->
+    <!-- Story creator mount -->
     <div id="story-generator-root"></div>
+
+    <aside id="research-packet-panel" class="research-packet-notepad" aria-hidden="true" aria-labelledby="research-packet-title">
+        <div class="research-packet-notepad-header">
+            <div>
+                <span class="research-packet-kicker">Research packet</span>
+                <h2 id="research-packet-title">Cited notes <span id="research-packet-count">0</span></h2>
+            </div>
+            <button type="button" id="research-packet-collapse" class="research-packet-collapse" aria-expanded="true" aria-label="Collapse research packet">−</button>
+        </div>
+        <div id="research-packet-content" class="research-packet-notepad-content">
+            <div class="research-packet-controls">
+                <label for="research-citation-style">Citation format</label>
+                <select id="research-citation-style">
+                    <option value="plain">Plain</option>
+                    <option value="mla">MLA</option>
+                    <option value="apa">APA</option>
+                    <option value="chicago">Chicago</option>
+                </select>
+            </div>
+            <div id="research-packet-list" class="research-packet-notepad-list"></div>
+            <div class="research-packet-notepad-actions">
+                <button id="copy-research-packet" type="button">Copy citations</button>
+                <button id="clear-research-packet" type="button">Clear</button>
+            </div>
+        </div>
+    </aside>
+
+    <div id="archive-onboarding" class="archive-onboarding" role="dialog" aria-modal="true" aria-labelledby="archive-onboarding-title" aria-hidden="true">
+        <div class="archive-onboarding-panel">
+            <div class="onboarding-topline">
+                <div>
+                    <span class="onboarding-kicker">A short orientation</span>
+                    <h2 id="archive-onboarding-title">Use the archive with context intact</h2>
+                </div>
+                <button type="button" class="onboarding-close" id="close-archive-guide" aria-label="Close archive guide">&times;</button>
+            </div>
+            <div class="onboarding-grid">
+                <div class="onboarding-item">
+                    <strong>Search broadly</strong>
+                    <span>Search reads titles, summaries, sources, authors, topics, and document types. Filters can narrow the result without changing the underlying record.</span>
+                </div>
+                <div class="onboarding-item">
+                    <strong>Read availability labels</strong>
+                    <span>Badges such as Archived, Source moved, or Source altered explain what copy is available. They describe access and provenance—not whether every claim is true.</span>
+                </div>
+                <div class="onboarding-item">
+                    <strong>Save a research packet</strong>
+                    <span>Use Save on any card or record detail. Saved material remains in this browser so you can build a focused set without creating an account.</span>
+                </div>
+                <div class="onboarding-item">
+                    <strong>Export citations</strong>
+                    <span>The research packet can copy Plain, MLA, APA, or Chicago citations. Always review generated citations against the original source before publication.</span>
+                </div>
+            </div>
+            <div class="onboarding-actions">
+                <span class="onboarding-note">This introduction appears automatically once.</span>
+                <button type="button" id="begin-archive" class="btn-primary px-6 py-3 rounded-sm text-xs uppercase tracking-widest">Explore the archive</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="witness-mode" class="witness-mode" role="dialog" aria-modal="true" aria-labelledby="witness-title" aria-hidden="true">
+        <div class="witness-panel">
+            <div class="witness-header">
+                <span>Witness Mode · One record at a time</span>
+                <button type="button" id="close-witness-mode" class="witness-exit">Exit</button>
+            </div>
+            <div class="witness-content">
+                <div id="witness-date" class="witness-date"></div>
+                <h2 id="witness-title"></h2>
+                <p id="witness-summary" class="witness-summary"></p>
+                <p id="witness-source" class="witness-source"></p>
+                <button type="button" id="witness-open-record" class="witness-open-record">Open record details</button>
+            </div>
+            <div class="witness-controls">
+                <button type="button" id="witness-previous">Previous</button>
+                <span id="witness-position" class="witness-position"></span>
+                <button type="button" id="witness-next">Next record</button>
+            </div>
+        </div>
+    </div>
+
+    <nav class="archive-orientation" aria-label="Page orientation">
+        <div class="archive-orientation-inner">
+            <a href="#top" data-orientation-target="top">Introduction</a>
+            <a href="#research-pathways" data-orientation-target="research-pathways">Research paths</a>
+            <a href="#articles" data-orientation-target="articles">Archive</a>
+            <a href="#geolocation" data-orientation-target="geolocation">Maps</a>
+            <a href="#victims" data-orientation-target="victims">Victims</a>
+        </div>
+    </nav>
+
+    <div id="archive-mobile-map" class="archive-mobile-map">
+        <div class="archive-mobile-map-menu" aria-label="Jump to page section">
+            <a href="#top" data-orientation-target="top">Introduction</a>
+            <a href="#research-pathways" data-orientation-target="research-pathways">Research paths</a>
+            <a href="#articles" data-orientation-target="articles">Archive</a>
+            <a href="#geolocation" data-orientation-target="geolocation">Maps</a>
+            <a href="#victims" data-orientation-target="victims">Victims</a>
+        </div>
+        <button type="button" id="archive-mobile-map-button" class="archive-mobile-map-button" aria-expanded="false">Viewing: Introduction</button>
+    </div>
 
     <!-- Google Translate -->
     <script type="text/javascript">
@@ -2867,6 +2931,93 @@
             { id: 'apa', label: 'APA' },
             { id: 'chicago', label: 'Chicago' }
         ];
+        const ARCHIVE_GUIDE_KEY = 'echoes_archive_guide_seen_v1';
+        const CLAIM_LENSES = [
+            {
+                id: 'aid-access',
+                label: '“Humanitarian aid has entered Gaza without meaningful restriction.”',
+                note: 'Records related to crossings, aid delivery, distribution sites, hunger, blockade, and access. Their presence does not by itself resolve the claim; read the dates, sources, and underlying evidence.',
+                terms: ['aid', 'crossing', 'food distribution', 'humanitarian access', 'blockade', 'starvation', 'hunger', 'famine', 'malnutrition']
+            },
+            {
+                id: 'safe-evacuation',
+                label: '“Evacuation orders consistently moved civilians toward safety.”',
+                note: 'Records related to evacuation orders, designated zones, displacement, shelters, and attacks affecting displaced people. Compare the sequence and location reported by each source.',
+                terms: ['evacuation', 'safe zone', 'humanitarian zone', 'displaced', 'displacement', 'shelter', 'tent camp', 'forced displacement']
+            },
+            {
+                id: 'healthcare-protection',
+                label: '“Hospitals and medical workers remained protected.”',
+                note: 'Records related to hospitals, clinics, ambulances, medical workers, detention of healthcare staff, and medicine shortages.',
+                terms: ['hospital', 'clinic', 'healthcare', 'health care', 'medical worker', 'doctor', 'ambulance', 'medicine', 'medication']
+            },
+            {
+                id: 'press-access',
+                label: '“Independent reporting from Gaza remained adequately accessible.”',
+                note: 'Records related to journalist deaths, access restrictions, communications blackouts, detention, and the conditions under which reporting was produced.',
+                terms: ['journalist', 'press freedom', 'media access', 'reporter', 'communications blackout', 'internet blackout', 'press']
+            }
+        ];
+        const EVIDENCE_THREADS = [
+            {
+                id: 'displacement',
+                label: 'Orders, displacement, and shelter',
+                note: 'A curated chronology connecting evacuation orders, repeated forced movement, attacks on shelters, the collapse of adequate housing, and the conditions facing families who have nowhere safe to go.',
+                titleFragments: [
+                    'Hopeless, Starving, and Besieged',
+                    'Israeli Strike Kills Gazans Sheltering in Warehouse',
+                    'Israel Orders Total Evacuation of Gaza City',
+                    'Facing Israeli Assault, Many in Gaza City Say Fleeing Again Is Worse',
+                    'Humanitarian Situation Update #323 | Gaza Strip',
+                    'Tents supplied to displaced Palestinians',
+                    'Israel orders Gaza families to move in first forced evacuation since ceasefire',
+                    'Domicide: Mass destruction of housing and civilian infrastructure in Gaza'
+                ],
+                fallbackTerms: ['forced displacement', 'evacuation order', 'displaced palestinians', 'shelter materials', 'domicide']
+            },
+            {
+                id: 'hunger',
+                label: 'Aid access and engineered hunger',
+                note: 'A curated chronology tracing aid restrictions, attacks and deaths around food access, escalating malnutrition, formal famine findings, and evidence concerning deliberate policy.',
+                titleFragments: [
+                    'Children?s lives threatened by rising malnutrition',
+                    'In Private, Some Israeli Officers Admit That Gaza Is on the Brink of Starvation',
+                    'At least 51 Palestinians killed while waiting for aid trucks',
+                    'In Gaza, mounting evidence of famine and widespread starvation',
+                    'New testimonies provide compelling evidence that Israel?s starvation of Palestinians in Gaza is a deliberate policy',
+                    'For the first time, the world?s food crises authority announces a famine',
+                    'How Israeli actions caused famine in Gaza, visualized',
+                    'Starvation by design',
+                    'Israeli study finds starvation in Gaza was result of deliberate policy'
+                ],
+                fallbackTerms: ['starvation', 'famine', 'malnutrition', 'aid trucks', 'aid restrictions']
+            },
+            {
+                id: 'journalists',
+                label: 'Journalists and the record',
+                note: 'A curated chronology connecting attacks on Palestinian journalists, conditions of reporting, disputed military rationales, restrictions on independent access, and the continuing struggle to preserve a public record.',
+                titleFragments: [
+                    'Israeli military accused of targeting journalists and their families',
+                    'Israeli military forced journalists and health workers to strip',
+                    'AFP journalists warn their',
+                    'The Deadly Risks of Reporting in Gaza',
+                    'Reuters stopped sharing Gaza locations with Israel',
+                    'A Times visual investigation contradicts',
+                    'Visual evidence upends Israel?s official story for deadly attack on Gaza hospital',
+                    'Israeli Ban on Media Entering Gaza Remains',
+                    'Record 129 press members killed in 2025',
+                    'Media organizations call on Israel to allow foreign reporters independent access'
+                ],
+                fallbackTerms: ['journalists access', 'killed journalists', 'press freedom', 'foreign reporters', 'media entering gaza']
+            }
+        ];
+        let pathwayArticleRecords = {};
+        let activeClaimId = CLAIM_LENSES[0].id;
+        let activeThreadId = EVIDENCE_THREADS[0].id;
+        let witnessRecords = [];
+        let witnessIndex = 0;
+        let archiveExperienceInitialized = false;
+        const displayZoomVisibleSections = new Set();
 
         // Escape a value used as a JS string literal inside an inline onclick attribute:
         // backslash-escape for the JS string, then HTML-escape so it cannot break out of the attribute.
@@ -2910,6 +3061,7 @@
             document.getElementById('view-cards-btn')?.classList.toggle('active', currentArchiveView === 'cards');
             document.getElementById('view-table-btn')?.classList.toggle('active', currentArchiveView === 'table');
             renderArticles(currentlyDisplayedArticles);
+            updateDesktopDisplayZoomVisibility();
         }
 
         // Helper to format date
@@ -2938,13 +3090,13 @@
         }
 
         function getArticleAuthors(article) {
-            if (Array.isArray(article.authors) && article.authors.length) {
-                return article.authors.filter(Boolean);
-            }
-            if (article.author) {
-                return String(article.author).split(/\s*(?:,|;| and )\s*/i).filter(Boolean);
-            }
-            return ['Unknown author'];
+            const listedAuthors = Array.isArray(article.authors) ? article.authors.filter(Boolean) : [];
+            const legacyAuthors = article.author
+                ? String(article.author).split(/\s*(?:,|;| and )\s*/i).filter(Boolean)
+                : [];
+            const combined = [...new Set([...listedAuthors, ...legacyAuthors])];
+            const named = combined.filter(author => !/unknown author/i.test(author));
+            return named.length ? named : (combined.length ? combined : ['Unknown author']);
         }
 
         function getArticleDocumentType(article) {
@@ -2995,6 +3147,379 @@
             if (!modal || !messageEl) return;
             messageEl.textContent = message;
             modal.classList.add('is-visible');
+        }
+
+        function searchableArticleText(article) {
+            return [
+                article?.title,
+                article?.summary,
+                article?.source,
+                ...getArticleCategories(article),
+                ...getArticleAuthors(article)
+            ].filter(Boolean).join(' ').toLowerCase();
+        }
+
+        function recordsMatchingTerms(terms) {
+            const normalizedTerms = terms.map(term => term.toLowerCase());
+            return articles.filter(article => {
+                const text = searchableArticleText(article);
+                return normalizedTerms.some(term => text.includes(term));
+            });
+        }
+
+        function registerPathwayArticle(article) {
+            const id = `pathway-${packetHash(`${article?.link || ''}|${article?.title || ''}`)}`;
+            pathwayArticleRecords[id] = article;
+            return id;
+        }
+
+        window.openPathwayArticle = function(id) {
+            const article = pathwayArticleRecords[id];
+            if (!article) return;
+            const detailId = `detail-${Math.random().toString(36).slice(2, 10)}`;
+            articleDetailRecords[detailId] = article;
+            window.openArticleDetail(detailId);
+        };
+
+        function sampleAcrossTimeline(items, limit = 7) {
+            const sorted = [...items].sort((a, b) => chronologicalValue(a) - chronologicalValue(b));
+            if (sorted.length <= limit) return sorted;
+            const sampled = [];
+            for (let index = 0; index < limit; index += 1) {
+                const position = Math.round(index * (sorted.length - 1) / (limit - 1));
+                sampled.push(sorted[position]);
+            }
+            return [...new Map(sampled.map(article => [article.link || article.title, article])).values()];
+        }
+
+        function normalizedTitle(value) {
+            return String(value || '')
+                .toLowerCase()
+                .replace(/[?‘’“”'":.,—–-]/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+        }
+
+        function curatedThreadRecords(thread) {
+            const chosen = [];
+            const seen = new Set();
+            (thread.titleFragments || []).forEach(fragment => {
+                const normalizedFragment = normalizedTitle(fragment);
+                const article = articles.find(candidate => {
+                    const title = normalizedTitle(candidate.title);
+                    return title.includes(normalizedFragment)
+                        || (title.length >= 24 && normalizedFragment.includes(title));
+                });
+                if (!article) return;
+                const key = article.link || article.title;
+                if (seen.has(key)) return;
+                seen.add(key);
+                chosen.push(article);
+            });
+
+            if (chosen.length < 8) {
+                recordsMatchingTerms(thread.fallbackTerms || []).forEach(article => {
+                    const key = article.link || article.title;
+                    if (seen.has(key) || chosen.length >= 10) return;
+                    seen.add(key);
+                    chosen.push(article);
+                });
+            }
+
+            return chosen.sort((a, b) => chronologicalValue(a) - chronologicalValue(b));
+        }
+
+        function renderClaimLens() {
+            const selector = document.getElementById('claim-selector');
+            const result = document.getElementById('claim-result');
+            if (!selector || !result || !articles.length) return;
+            const active = CLAIM_LENSES.find(item => item.id === activeClaimId) || CLAIM_LENSES[0];
+
+            selector.innerHTML = `
+                <span class="pathway-selector-label">Choose a claim</span>
+                ${CLAIM_LENSES.map(item => `
+                    <button type="button" class="pathway-select-button ${item.id === active.id ? 'is-active' : ''}" data-claim-id="${escapeDataAttribute(item.id)}">${escapeHtml(item.label)}</button>
+                `).join('')}
+            `;
+
+            const matches = newestFirst(recordsMatchingTerms(active.terms)).slice(0, 8);
+            result.innerHTML = `
+                <div class="pathway-result-header">
+                    <h3>${escapeHtml(active.label)}</h3>
+                    <p>${escapeHtml(active.note)} ${matches.length.toLocaleString()} recent relevant records are shown from ${recordsMatchingTerms(active.terms).length.toLocaleString()} matches.</p>
+                </div>
+                <div class="claim-records">
+                    ${matches.map(article => {
+                        const id = registerPathwayArticle(article);
+                        return `
+                            <button type="button" class="claim-record" onclick="window.openPathwayArticle('${id}')">
+                                <span class="claim-record-meta">${escapeHtml(formatDate(article.date))} · ${escapeHtml(article.source || 'Unknown source')}</span>
+                                <span class="claim-record-title">${escapeHtml(article.title || 'Untitled')}</span>
+                            </button>
+                        `;
+                    }).join('')}
+                </div>
+            `;
+
+            selector.querySelectorAll('[data-claim-id]').forEach(button => {
+                button.addEventListener('click', () => {
+                    activeClaimId = button.dataset.claimId;
+                    renderClaimLens();
+                });
+            });
+        }
+
+        function renderEvidenceThread() {
+            const selector = document.getElementById('thread-selector');
+            const result = document.getElementById('thread-result');
+            if (!selector || !result || !articles.length) return;
+            const active = EVIDENCE_THREADS.find(item => item.id === activeThreadId) || EVIDENCE_THREADS[0];
+
+            selector.innerHTML = `
+                <span class="pathway-selector-label">Choose a thread</span>
+                ${EVIDENCE_THREADS.map(item => `
+                    <button type="button" class="pathway-select-button ${item.id === active.id ? 'is-active' : ''}" data-thread-id="${escapeDataAttribute(item.id)}">${escapeHtml(item.label)}</button>
+                `).join('')}
+            `;
+
+            const sampled = curatedThreadRecords(active);
+            result.innerHTML = `
+                <div class="pathway-result-header">
+                    <h3>${escapeHtml(active.label)}</h3>
+                    <p>${escapeHtml(active.note)} These ${sampled.length} records were selected for direct relevance and chronological continuity; the thread remains a guided path, not a complete account.</p>
+                </div>
+                <div class="thread-line">
+                    ${sampled.map(article => {
+                        const id = registerPathwayArticle(article);
+                        return `
+                            <div class="thread-step">
+                                <button type="button" class="thread-record w-full" onclick="window.openPathwayArticle('${id}')">
+                                    <span class="thread-record-meta">${escapeHtml(formatDate(article.date))} · ${escapeHtml(article.source || 'Unknown source')}</span>
+                                    <span class="thread-record-title">${escapeHtml(article.title || 'Untitled')}</span>
+                                </button>
+                            </div>
+                        `;
+                    }).join('')}
+                </div>
+            `;
+
+            selector.querySelectorAll('[data-thread-id]').forEach(button => {
+                button.addEventListener('click', () => {
+                    activeThreadId = button.dataset.threadId;
+                    renderEvidenceThread();
+                });
+            });
+        }
+
+        function renderArchivePathways() {
+            pathwayArticleRecords = {};
+            renderClaimLens();
+            renderEvidenceThread();
+        }
+
+        function activeFilterDescriptors() {
+            const descriptors = [];
+            const search = document.getElementById('article-search')?.value.trim();
+            const start = document.getElementById('start-date')?.value;
+            const end = document.getElementById('end-date')?.value;
+            if (search) descriptors.push({ type: 'search', label: `Search: ${search}` });
+            if (start) descriptors.push({ type: 'start-date', label: `From ${start}` });
+            if (end) descriptors.push({ type: 'end-date', label: `Through ${end}` });
+            document.querySelectorAll('input[data-filter-type]:checked').forEach(input => {
+                descriptors.push({ type: input.dataset.filterType, value: input.value, label: input.value });
+            });
+            return descriptors;
+        }
+
+        function updateFilterAffordances() {
+            const descriptors = activeFilterDescriptors();
+            const badge = document.getElementById('filter-count-badge');
+            const strip = document.getElementById('active-filter-strip');
+            const chips = document.getElementById('active-filter-chips');
+            if (badge) {
+                badge.textContent = String(descriptors.length);
+                badge.hidden = descriptors.length === 0;
+            }
+            if (!strip || !chips) return;
+            strip.classList.toggle('has-filters', descriptors.length > 0);
+            chips.innerHTML = descriptors.map((descriptor, index) => `
+                <button type="button" class="active-filter-chip" data-filter-chip-index="${index}" aria-label="Remove ${escapeHtmlAttribute(descriptor.label)}">
+                    ${escapeHtml(descriptor.label)} <span aria-hidden="true">×</span>
+                </button>
+            `).join('');
+            chips.querySelectorAll('[data-filter-chip-index]').forEach(button => {
+                button.addEventListener('click', () => {
+                    const descriptor = descriptors[Number(button.dataset.filterChipIndex)];
+                    if (!descriptor) return;
+                    if (descriptor.type === 'search') document.getElementById('article-search').value = '';
+                    else if (descriptor.type === 'start-date') document.getElementById('start-date').value = '';
+                    else if (descriptor.type === 'end-date') document.getElementById('end-date').value = '';
+                    else {
+                        document.querySelectorAll(`input[data-filter-type="${descriptor.type}"]`).forEach(input => {
+                            if (input.value === descriptor.value) input.checked = false;
+                        });
+                    }
+                    applyArchiveFilters();
+                });
+            });
+        }
+
+        function updatePendingFilterCount() {
+            const badge = document.getElementById('filter-count-badge');
+            if (!badge) return;
+            const count = activeFilterDescriptors().length;
+            badge.textContent = String(count);
+            badge.hidden = count === 0;
+        }
+
+        function openArchiveGuide(force = false) {
+            const guide = document.getElementById('archive-onboarding');
+            if (!guide) return;
+            if (!force) {
+                try {
+                    if (localStorage.getItem(ARCHIVE_GUIDE_KEY) === 'seen') return;
+                } catch (error) {}
+            }
+            guide.classList.add('is-visible');
+            guide.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('archive-overlay-open');
+            document.getElementById('begin-archive')?.focus();
+        }
+
+        function closeArchiveGuide() {
+            const guide = document.getElementById('archive-onboarding');
+            if (!guide) return;
+            guide.classList.remove('is-visible');
+            guide.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('archive-overlay-open');
+            try {
+                localStorage.setItem(ARCHIVE_GUIDE_KEY, 'seen');
+            } catch (error) {}
+        }
+
+        function renderWitnessRecord() {
+            if (!witnessRecords.length) return;
+            const article = witnessRecords[witnessIndex];
+            document.getElementById('witness-date').textContent = formatDate(article.date);
+            document.getElementById('witness-title').textContent = article.title || 'Untitled record';
+            document.getElementById('witness-summary').textContent = article.summary || 'No summary is available for this record.';
+            document.getElementById('witness-source').textContent = `${article.source || 'Unknown source'}${getArticleAuthors(article).some(author => !/unknown author/i.test(author)) ? ` · ${getArticleAuthors(article).join(', ')}` : ''}`;
+            document.getElementById('witness-position').textContent = `${witnessIndex + 1} of ${witnessRecords.length}`;
+        }
+
+        function openWitnessMode() {
+            const base = currentlyDisplayedArticles.length ? currentlyDisplayedArticles : articles;
+            const witnessTerms = ['child', 'family', 'displaced', 'patient', 'doctor', 'journalist', 'testimony', 'surviv', 'killed', 'injured', 'hunger', 'shelter'];
+            const candidates = base.filter(article => {
+                const summary = String(article.summary || '').trim();
+                if (summary.length < 100) return false;
+                const text = searchableArticleText(article);
+                return witnessTerms.some(term => text.includes(term));
+            });
+            const fallback = base.filter(article => String(article.summary || '').trim().length >= 100);
+            witnessRecords = sampleAcrossTimeline(candidates.length ? candidates : fallback, 60);
+            if (!witnessRecords.length) return;
+            witnessIndex = 0;
+            renderWitnessRecord();
+            const modal = document.getElementById('witness-mode');
+            modal.classList.add('is-visible');
+            modal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('archive-overlay-open');
+            document.getElementById('close-witness-mode')?.focus();
+        }
+
+        function closeWitnessMode() {
+            const modal = document.getElementById('witness-mode');
+            modal.classList.remove('is-visible');
+            modal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('archive-overlay-open');
+        }
+
+        function openCurrentWitnessRecord() {
+            const article = witnessRecords[witnessIndex];
+            if (!article) return;
+            closeWitnessMode();
+            const detailId = `detail-${Math.random().toString(36).slice(2, 10)}`;
+            articleDetailRecords[detailId] = article;
+            window.openArticleDetail(detailId);
+        }
+
+        function setupArchiveOrientation() {
+            const links = Array.from(document.querySelectorAll('[data-orientation-target]'));
+            const targets = [...new Set(links.map(link => link.dataset.orientationTarget))]
+                .map(id => document.getElementById(id))
+                .filter(Boolean);
+            const mobileButton = document.getElementById('archive-mobile-map-button');
+            const mobileMap = document.getElementById('archive-mobile-map');
+            const labels = {
+                top: 'Introduction',
+                'research-pathways': 'Research paths',
+                articles: 'Archive',
+                geolocation: 'Maps',
+                victims: 'Victims',
+            };
+            const setActive = id => {
+                links.forEach(link => link.classList.toggle('is-active', link.dataset.orientationTarget === id));
+                if (mobileButton) mobileButton.textContent = `Viewing: ${labels[id] || 'Page'}`;
+            };
+            if ('IntersectionObserver' in window) {
+                const observer = new IntersectionObserver(entries => {
+                    const visible = entries
+                        .filter(entry => entry.isIntersecting)
+                        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+                    if (visible) setActive(visible.target.id);
+                }, { rootMargin: '-20% 0px -65% 0px', threshold: [0, 0.1, 0.4] });
+                targets.forEach(target => observer.observe(target));
+            }
+            mobileButton?.addEventListener('click', () => {
+                const open = mobileMap.classList.toggle('is-open');
+                mobileButton.setAttribute('aria-expanded', String(open));
+            });
+            links.forEach(link => link.addEventListener('click', () => {
+                mobileMap?.classList.remove('is-open');
+                mobileButton?.setAttribute('aria-expanded', 'false');
+            }));
+            setActive('top');
+        }
+
+        function setupArchiveExperience() {
+            if (archiveExperienceInitialized) return;
+            archiveExperienceInitialized = true;
+            document.querySelectorAll('[data-pathway-tab]').forEach(tab => {
+                tab.addEventListener('click', () => {
+                    const panelId = tab.dataset.pathwayTab;
+                    document.querySelectorAll('[data-pathway-tab]').forEach(item => item.setAttribute('aria-selected', String(item === tab)));
+                    document.querySelectorAll('.archive-pathway-panel').forEach(panel => {
+                        panel.hidden = panel.id !== panelId;
+                    });
+                });
+            });
+            document.getElementById('open-witness-mode')?.addEventListener('click', openWitnessMode);
+            document.getElementById('close-witness-mode')?.addEventListener('click', closeWitnessMode);
+            document.getElementById('witness-previous')?.addEventListener('click', () => {
+                witnessIndex = (witnessIndex - 1 + witnessRecords.length) % witnessRecords.length;
+                renderWitnessRecord();
+            });
+            document.getElementById('witness-next')?.addEventListener('click', () => {
+                witnessIndex = (witnessIndex + 1) % witnessRecords.length;
+                renderWitnessRecord();
+            });
+            document.getElementById('witness-open-record')?.addEventListener('click', openCurrentWitnessRecord);
+            document.getElementById('open-archive-guide')?.addEventListener('click', () => openArchiveGuide(true));
+            document.getElementById('close-archive-guide')?.addEventListener('click', closeArchiveGuide);
+            document.getElementById('begin-archive')?.addEventListener('click', closeArchiveGuide);
+            document.getElementById('archive-onboarding')?.addEventListener('click', event => {
+                if (event.target.id === 'archive-onboarding') closeArchiveGuide();
+            });
+            document.getElementById('witness-mode')?.addEventListener('click', event => {
+                if (event.target.id === 'witness-mode') closeWitnessMode();
+            });
+            document.addEventListener('keydown', event => {
+                if (event.key !== 'Escape') return;
+                if (document.getElementById('witness-mode')?.classList.contains('is-visible')) closeWitnessMode();
+                else if (document.getElementById('archive-onboarding')?.classList.contains('is-visible')) closeArchiveGuide();
+            });
+            setupArchiveOrientation();
         }
 
         function packetHash(value) {
@@ -3180,6 +3705,41 @@
             document.getElementById('desktop-display-zoom-range')?.addEventListener('input', (event) => {
                 setDesktopDisplayZoom(event.target.value);
             });
+
+            const sections = Array.from(document.querySelectorAll('#articles, #books, #videos, #films'));
+            if (!sections.length) return;
+
+            if (!('IntersectionObserver' in window)) {
+                displayZoomVisibleSections.add('articles');
+                updateDesktopDisplayZoomVisibility();
+                return;
+            }
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) displayZoomVisibleSections.add(entry.target.id);
+                    else displayZoomVisibleSections.delete(entry.target.id);
+                });
+                updateDesktopDisplayZoomVisibility();
+            }, {
+                root: null,
+                rootMargin: '-18% 0px -18% 0px',
+                threshold: 0.01
+            });
+
+            sections.forEach(section => observer.observe(section));
+            updateDesktopDisplayZoomVisibility();
+        }
+
+        function updateDesktopDisplayZoomVisibility() {
+            const control = document.querySelector('.desktop-display-zoom');
+            if (!control) return;
+            const visibleSection = [...displayZoomVisibleSections].find(id => {
+                if (id === 'articles' && currentArchiveView !== 'cards') return false;
+                return true;
+            });
+            control.classList.toggle('is-context-visible', Boolean(visibleSection));
+            control.setAttribute('aria-hidden', String(!visibleSection));
         }
 
         function effectiveIntegrityResult(result) {
@@ -3633,27 +4193,28 @@
         };
 
         function renderResearchPacket() {
-            const summary = document.getElementById('research-packet-summary');
+            const panel = document.getElementById('research-packet-panel');
             const list = document.getElementById('research-packet-list');
-            const actions = document.getElementById('research-packet-actions');
-            if (!summary || !list) return;
+            const count = document.getElementById('research-packet-count');
+            if (!panel || !list) return;
             const savedArticles = getSavedResearchArticles();
             const citationStyle = document.getElementById('research-citation-style')?.value || 'plain';
-            const citationLabel = CITATION_STYLES.find(style => style.id === citationStyle)?.label || 'Plain';
-            if (actions) actions.classList.toggle('hidden', !savedArticles.length);
-            summary.textContent = savedArticles.length
-                ? `${savedArticles.length.toLocaleString()} saved article${savedArticles.length === 1 ? '' : 's'} ready for ${citationLabel} citation export.`
-                : 'No articles saved yet.';
-            list.innerHTML = savedArticles.length ? savedArticles.slice(0, 8).map(article => {
+            const hasArticles = savedArticles.length > 0;
+            panel.classList.toggle('is-visible', hasArticles);
+            panel.setAttribute('aria-hidden', String(!hasArticles));
+            if (count) count.textContent = savedArticles.length.toLocaleString();
+            list.innerHTML = savedArticles.map(article => {
                 const id = articlePacketId(article);
                 return `
-                    <div class="border border-white/5 bg-[#0a0a0a] p-4">
-                        <div class="text-[10px] text-gray-600 uppercase tracking-widest mb-2">${escapeHtml(article.source || '')} / ${escapeHtml(article.date || '')}</div>
-                        <div class="text-sm text-gray-300 font-serif leading-snug mb-3">${escapeHtml(article.title || 'Untitled')}</div>
-                        <button class="text-[10px] text-[#8B0000] hover:text-white uppercase tracking-widest" onclick="window.removeFromResearchPacket('${id}')">Remove</button>
+                    <div class="research-packet-note">
+                        <div class="research-packet-note-meta">
+                            <span>${escapeHtml(article.source || 'Unknown source')} · ${escapeHtml(article.date || 'n.d.')}</span>
+                            <button type="button" onclick="window.removeFromResearchPacket('${id}')">Remove</button>
+                        </div>
+                        <div class="research-packet-citation">${escapeHtml(citationForArticle(article, citationStyle))}</div>
                     </div>
                 `;
-            }).join('') : '<p class="text-sm text-gray-600 italic">Use the Save button on article cards or details to build a research packet.</p>';
+            }).join('');
         }
 
         window.removeFromResearchPacket = function(id) {
@@ -3876,6 +4437,7 @@
 
         function updateArchiveResultSummary(filtered) {
             const summaryEl = document.getElementById('active-filter-summary');
+            updateFilterAffordances();
             if (!summaryEl) return;
             const selected = Array.from(document.querySelectorAll('input[data-filter-type]:checked')).map(input => input.value);
             const search = document.getElementById('article-search')?.value.trim();
@@ -3951,6 +4513,7 @@
                 renderRelatedCategorySuggestions(currentlyDisplayedArticles);
                 renderResearchPacket();
                 renderArticles(currentlyDisplayedArticles);
+                renderArchivePathways();
                 return true;
             } catch (error) {
                 console.error('Failed to load articles:', error);
@@ -3995,6 +4558,8 @@
             });
 
             currentlyDisplayedArticles = filtered;
+            updateArchiveResultSummary(filtered);
+            renderRelatedCategorySuggestions(filtered);
             renderArticles(currentlyDisplayedArticles);
             document.getElementById('articles').scrollIntoView({ behavior: 'smooth' });
         }
@@ -4615,6 +5180,7 @@
             }
             setupDropdowns();
             setupHiddenToolNavigation();
+            setupArchiveExperience();
             document.getElementById('displacement-map-load')?.addEventListener('click', revealDisplacementMap);
             initLazyMapEmbeds();
             initMobileDensityControl();
@@ -4654,6 +5220,14 @@
             });
             document.getElementById('copy-research-packet')?.addEventListener('click', copyResearchPacketCitations);
             document.getElementById('research-citation-style')?.addEventListener('change', renderResearchPacket);
+            document.getElementById('research-packet-collapse')?.addEventListener('click', (event) => {
+                const panel = document.getElementById('research-packet-panel');
+                if (!panel) return;
+                const collapsed = panel.classList.toggle('is-collapsed');
+                event.currentTarget.textContent = collapsed ? '+' : '−';
+                event.currentTarget.setAttribute('aria-expanded', String(!collapsed));
+                event.currentTarget.setAttribute('aria-label', collapsed ? 'Expand research packet' : 'Collapse research packet');
+            });
             document.getElementById('clear-research-packet')?.addEventListener('click', () => {
                 researchPacket = [];
                 saveResearchPacket();
@@ -4674,6 +5248,9 @@
             // Integrity data is loaded inside loadArticles() (before the first
             // article render) so provenance badges paint without a flash.
             if (!articlesLoaded) loadIntegrityReport();
+            if (articlesLoaded) {
+                window.setTimeout(() => openArchiveGuide(false), 1600);
+            }
 
             fetchVictimsData();
             if (articlesLoaded && articles.length > 0) initEmbeddedQuiz();
@@ -4750,9 +5327,14 @@
 
             document.getElementById('toggle-filter-btn').addEventListener('click', (e) => {
                 const panel = document.getElementById('filter-controls');
+                const isOpening = panel.classList.contains('hidden');
                 panel.classList.toggle('hidden');
-                e.target.classList.toggle('active');
+                e.currentTarget.classList.toggle('active', isOpening);
+                e.currentTarget.setAttribute('aria-expanded', String(isOpening));
+                document.body.classList.toggle('archive-filters-open', isOpening);
             });
+
+            document.getElementById('filter-controls')?.addEventListener('change', updatePendingFilterCount);
 
             const compareBtn = document.getElementById('toggle-comparison-btn');
             const comparisonSection = document.getElementById('comparison-section');
@@ -4773,6 +5355,8 @@
                 applyArchiveFilters();
                 document.getElementById('filter-controls').classList.add('hidden');
                 document.getElementById('toggle-filter-btn').classList.remove('active');
+                document.getElementById('toggle-filter-btn').setAttribute('aria-expanded', 'false');
+                document.body.classList.remove('archive-filters-open');
             });
 
             document.getElementById('clear-button').addEventListener('click', () => {
@@ -4835,8 +5419,8 @@
         });
     </script>
 
-    <!-- REACT STORY GENERATOR COMPONENT -->
-    <script type="text/babel">
+    <!-- Legacy story generator retained as inert source during the native migration. -->
+    <script type="text/plain" data-legacy-story-generator>
         const { useState, useEffect, useRef } = React;
 
         const Icons = {
@@ -5118,6 +5702,7 @@
             root.render(<StoryGenerator />);
         }
     </script>
+    <script src="./assets/story-generator.js?v=1"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const heroVideo = document.querySelector('.hero-bg-video');
@@ -5155,6 +5740,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/indexLITE.html
+++ b/indexLITE.html
@@ -367,7 +367,7 @@
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">
@@ -420,7 +420,7 @@
                              <a href="https://echoesofgaza.org/podcast" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Podcast</a>
                                 <a href="#quotes" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Quotes & Resources</a>
                                 <a href="https://echoesofgaza.org/events" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Events</a>
-                                <a href="#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
+                                <a href="./about.html#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
                                 <a href="https://echoesofgaza.org/toolkit" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Toolkit</a>
                 
                             </div>
@@ -459,7 +459,7 @@
             <a href="#quotes" class="mobile-nav-link text-gray-400 hover:text-white transition">Resources</a>
             <a href="https://echoesofgaza.org/events" class="mobile-nav-link text-gray-400 hover:text-white transition">Events</a>
             <a href="https://echoesofgaza.org/podcast"  class="mobile-nav-link text-gray-400 hover:text-white transition">EOG Podcast</a>
-            <a href="#faq" class="mobile-nav-link text-gray-400 hover:text-white transition">FAQ</a>
+            <a href="./about.html" class="mobile-nav-link text-gray-400 hover:text-white transition">About</a>
             <a href="https://echoesofgaza.org/collab" class="mobile-nav-link btn-primary px-8 py-3 rounded text-sm uppercase">Submit Evidence</a>
         </nav>
     </div>
@@ -2045,6 +2045,6 @@ document.addEventListener('DOMContentLoaded', loadArticles);
             root.render(<StoryGenerator />);
         }
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/podcast.html
+++ b/podcast.html
@@ -148,7 +148,7 @@
             transform: translateY(0);
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="antialiased min-h-screen flex flex-col items-center">
 
@@ -201,7 +201,7 @@
                             <div class="bg-[#0a0a0a] border border-[#222] shadow-2xl">
                                 <a href="#quotes" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Quotes & Resources</a>
                                 <a href="https://echoesofgaza.org/events" target="_blank" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Events</a>
-                                <a href="#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
+                                <a href="./about.html#faq" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">FAQ</a>
                             </div>
                         </div>
                     </div>
@@ -437,6 +437,6 @@
             }, 2000);
         }
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/primary.html
+++ b/primary.html
@@ -106,7 +106,7 @@
             background-color: #601414;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="bg-void text-bone min-h-screen font-body selection:bg-blood selection:text-white antialiased">
 
@@ -696,6 +696,6 @@
         });
 
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://echoesofgaza.org/</loc>
-    <lastmod>2026-06-01</lastmod>
+    <lastmod>2026-06-18</lastmod>
+  </url>
+  <url>
+    <loc>https://echoesofgaza.org/about</loc>
+    <lastmod>2026-06-18</lastmod>
   </url>
   <url>
     <loc>https://echoesofgaza.org/blog</loc>

--- a/toolkit.html
+++ b/toolkit.html
@@ -107,7 +107,7 @@
             -webkit-box-decoration-break: clone;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
     <style>
         /* This page has a fixed left section sidebar; offset the shared site footer
            to clear it on desktop so the footer matches the layout of the main content. */
@@ -1155,6 +1155,6 @@
             setTimeout(updateNav, 100);
         });
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>

--- a/zionism_divide.html
+++ b/zionism_divide.html
@@ -222,7 +222,7 @@
         }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-1">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
 </head>
 <body class="antialiased pb-20">
 
@@ -768,6 +768,6 @@
     <script>
         lucide.createIcons();
     </script>
-    <script src="./assets/site-shell.js?v=voices-1" defer></script>
+    <script src="./assets/site-shell.js?v=about-1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed
- removed the obsolete unknown-record pathway and the healthcare thread from Follow a Thread
- rebuilt the three remaining evidence threads around more directly relevant records, including new OCHA, OHCHR, and CPJ sources
- made the research packet invisible when empty and converted it into a compact floating cited notepad when records are saved
- limited desktop display-density controls to archive sections and card views where they work
- added a polished About page with the project mark, expanded feature guidance, and a redesigned FAQ
- linked About and FAQ from the shared navigation and footer, and tightened the mobile navigation height
- preserved the native story creator migration already present in the archive branch

## Validation
- `node scripts/validate_data.mjs`
- JavaScript syntax checks for shared and inline executable scripts
- duplicate-ID checks for `index.html` and `about.html`
- responsive browser verification at desktop and 390px mobile widths
- interaction checks for evidence threads, research packet save/collapse/clear, and display-control visibility

The unrelated local submission-script edits were intentionally excluded.