### PR TITLE
Fix hero background video autoplay on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1928,8 +1928,9 @@
     <!-- MAIN CONTENT -->
     <main>
         <section id="top" class="hero-section pt-32 pb-12">
-            <video class="hero-bg-video" autoplay muted loop playsinline webkit-playsinline preload="auto" aria-hidden="true">
+            <video class="hero-bg-video" autoplay muted loop playsinline webkit-playsinline preload="auto" disablepictureinpicture controlslist="nodownload nofullscreen noremoteplayback" aria-hidden="true">
                 <source src="https://pub-3592c0f33d62473e96882cebf2720dba.r2.dev/EoG%20-%20Background.mp4" type="video/mp4" />
+                <source src="./background.mp4" type="video/mp4" />
             </video>
             <div class="hero-video-overlay" aria-hidden="true"></div>
             <div class="max-w-7xl mx-auto px-6 lg:px-8 relative z-10 w-full">
@@ -5726,20 +5727,26 @@
                 heroVideo.setAttribute('webkit-playsinline', '');
 
                 const playHeroVideo = () => {
+                    if (!heroVideo.paused) return;
+
                     const playAttempt = heroVideo.play();
                     if (playAttempt && typeof playAttempt.catch === 'function') {
-                        playAttempt.catch(() => {
-                            heroVideo.load();
-                        });
+                        playAttempt.catch(() => {});
                     }
                 };
 
-                if (heroVideo.readyState >= 2) {
-                    playHeroVideo();
-                } else {
-                    heroVideo.addEventListener('canplay', playHeroVideo, { once: true });
-                    heroVideo.load();
-                }
+                heroVideo.addEventListener('loadeddata', playHeroVideo);
+                heroVideo.addEventListener('canplay', playHeroVideo);
+                window.addEventListener('pageshow', playHeroVideo);
+                document.addEventListener('visibilitychange', () => {
+                    if (!document.hidden) playHeroVideo();
+                });
+
+                ['touchstart', 'pointerdown', 'keydown'].forEach((eventName) => {
+                    document.addEventListener(eventName, playHeroVideo, { once: true, passive: true });
+                });
+
+                playHeroVideo();
             }
 
             const topAnnouncementBanner = document.getElementById('top-announcement-banner');


### PR DESCRIPTION
### Motivation
- Mobile visitors were seeing a play icon instead of the hero background video autoplaying, indicating the page's previous retry logic left playback unstarted on some devices. 
- Ensure the hero video autoplays reliably on mobile and desktop while preventing native playback overlays and using a local fallback if the hosted asset fails.

### Description
- Added `disablepictureinpicture` and `controlslist="nodownload nofullscreen noremoteplayback"` to the hero `<video>` and included a local `./background.mp4` `<source>` as a fallback. 
- Strengthened autoplay logic by protecting against repeated reloads: the code now skips replays when the video is already playing and no longer calls `load()` after a rejected play promise. 
- Added multiple retry triggers for playback by listening for `loadeddata`, `canplay`, `pageshow`, and `visibilitychange`, and by attaching a one-time listener for the visitor's first interaction events (`touchstart`, `pointerdown`, `keydown`). 
- Kept the video muted/inline attributes (`muted`, `defaultMuted`, `playsInline`, `playsinline`, `webkit-playsinline`) and call `playHeroVideo()` once at startup to attempt immediate playback.

### Testing
- Parsed `index.html` using Python's `HTMLParser` and the parse succeeded. 
- Confirmed the fallback file exists and is non-empty with `test -s background.mp4`. 
- Ran `git diff --check` to validate the working tree; no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a342a70aea48329957e877b706fe6e9)