### PR TITLE
[codex] Promote Voices in site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/site-tokens.css?v=design-1">
-  <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+  <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
   <link rel="stylesheet" href="./assets/about.css?v=1">
 </head>
 <body>
@@ -173,6 +173,6 @@
     </section>
   </main>
 
-  <script src="./assets/site-shell.js?v=about-1" defer></script>
+  <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/assets/site-shell.css
+++ b/assets/site-shell.css
@@ -71,6 +71,25 @@ body.site-shell-pad {
   color: rgba(255, 255, 255, 0.92);
 }
 
+.site-shell-nav > a.is-current,
+.site-shell-mobile a.is-current {
+  color: #fff;
+}
+
+.site-shell-nav > a.is-current {
+  position: relative;
+}
+
+.site-shell-nav > a.is-current::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.55rem;
+  height: 1px;
+  background: #c9a84c;
+}
+
 .site-shell-menu-wrap {
   position: relative;
   align-self: stretch;

--- a/assets/site-shell.js
+++ b/assets/site-shell.js
@@ -6,6 +6,7 @@
   if (isAdmin) return;
 
   const home = "https://echoesofgaza.org";
+  const isVoices = /\/blog(?:\/|\.html|$)/i.test(window.location.pathname);
   const navHtml = `
     <header class="site-shell-header" data-site-shell="header">
       <div class="site-shell-inner">
@@ -32,14 +33,14 @@
               </span>
             </span>
           </span>
-          <a href="${home}/#geolocation">Maps</a>
+          <a href="${home}/blog"${isVoices ? ' class="is-current"' : ""} ${isVoices ? 'aria-current="page"' : ""}>Voices</a>
           <a href="${home}/#victims">Victims</a>
           <span class="site-shell-menu-wrap">
             <button class="site-shell-menu-button" type="button">Resources</button>
             <span class="site-shell-menu">
               <span class="site-shell-menu-panel">
+                <a href="${home}/#geolocation">Maps & Geolocation</a>
                 <a href="${home}/#quotes">Quotes & Resources</a>
-                <a href="${home}/blog">Voices</a>
                 <a href="${home}/events">Events</a>
                 <a href="${home}/about">About</a>
                 <a href="${home}/about#faq">FAQ</a>
@@ -61,12 +62,12 @@
       </div>
       <nav class="site-shell-mobile-links" aria-label="Mobile navigation">
         <a href="${home}/#articles">Archive</a>
+        <a href="${home}/blog"${isVoices ? ' class="is-current"' : ""} ${isVoices ? 'aria-current="page"' : ""}>Voices</a>
         <a href="${home}/#casualty-graph">Timeline</a>
         <a href="${home}/#bias-tool-controls">Racial Bias Tool</a>
-        <a href="${home}/#geolocation">Maps</a>
         <a href="${home}/#victims">Victims</a>
+        <a href="${home}/#geolocation">Maps</a>
         <a href="${home}/events">Events</a>
-        <a href="${home}/blog">Voices</a>
         <a href="${home}/about">About</a>
         <a href="${home}/collab" class="site-shell-submit">Submit Evidence</a>
       </nav>
@@ -110,7 +111,7 @@
               <h4>Resources</h4>
               <ul>
                 <li><a href="${home}/#quotes">Quotes</a></li>
-                <li><a href="${home}/blog">Voices</a></li>
+                <li><a href="${home}/#geolocation">Maps & Geolocation</a></li>
                 <li><a href="${home}/about">About & FAQ</a></li>
                 <li><a href="https://data.techforpalestine.org/api/v2/killed-in-gaza.min.json" target="_blank" rel="noopener noreferrer">Raw Data</a></li>
               </ul>

--- a/blog.html
+++ b/blog.html
@@ -750,6 +750,7 @@
                 <div>
                     <h4 class="text-off-white/80 mb-6 text-xs uppercase tracking-widest font-sans font-bold">Resources</h4>
                     <ul class="space-y-3 text-xs text-ash-gray font-sans">
+                        <li><a href="https://echoesofgaza.org/#geolocation" class="hover:text-off-white transition-colors">Maps & Geolocation</a></li>
                         <li><a href="https://echoesofgaza.org/#quotes" class="hover:text-off-white transition-colors">Quotes</a></li>
                         <li><a href="https://data.techforpalestine.org/api/v2/killed-in-gaza.min.json" target="_blank" class="hover:text-off-white transition-colors">Raw Data</a></li>
                     </ul>

--- a/collab.html
+++ b/collab.html
@@ -405,7 +405,7 @@
             border-color: #4d1b1b;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="min-h-screen flex flex-col">
 
@@ -1984,6 +1984,6 @@
           }
         });
       </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/content_calendar.html
+++ b/content_calendar.html
@@ -54,7 +54,7 @@
             overflow: hidden;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="min-h-screen bg-[#FDFBF7] font-sans text-stone-900 selection:bg-emerald-100 selection:text-emerald-900 pb-16">
 
@@ -641,6 +641,6 @@ async function apiDeletePost(id) {
         loadData();
         
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/echoesindayton.html
+++ b/echoesindayton.html
@@ -21,7 +21,7 @@
         .font-serif { font-family: 'Playfair Display', serif; }
         .font-sans { font-family: 'Inter', sans-serif; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="min-h-screen bg-[#0B0B0B] text-[#EDEDED] selection:bg-[#8C0D0D] selection:text-[#EDEDED]">
 
@@ -276,6 +276,6 @@
             });
         });
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -156,7 +156,7 @@
             scroll-margin-top: 6rem;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="flex flex-col min-h-screen">
 
@@ -552,6 +552,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1892,7 +1892,7 @@
             }
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">
@@ -1942,7 +1942,7 @@
                         </div>
                     </div>
 
-                    <a href="#geolocation" class="nav-link">Maps</a>
+                    <a href="https://echoesofgaza.org/blog" class="nav-link">Voices</a>
                     <a href="#victims" class="nav-link">Victims</a>
 
                     <div class="relative group">
@@ -1951,8 +1951,8 @@
                         </button>
                         <div id="resources-menu-dropdown" class="absolute left-1/2 -translate-x-1/2 top-full pt-1 w-48 hidden group-hover:block z-50">
                             <div class="bg-[#0a0a0a] border border-[#222] shadow-2xl">
-                             <a href="https://echoesofgaza.org/blog" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Voices</a>
-                             <a href="https://echoesofgaza.org/podcast" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Podcast</a>
+                                <a href="#geolocation" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Maps & Geolocation</a>
+                                <a href="https://echoesofgaza.org/podcast" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">EoG Podcast</a>
                                 <a href="#quotes" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Quotes & Resources</a>
                                 <a href="https://echoesofgaza.org/events" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">Events</a>
                                 <a href="./about.html" class="block px-6 py-3 text-xs hover:bg-[#151515] transition text-gray-400 hover:text-white">About</a>
@@ -1990,9 +1990,10 @@
         </div>
         <nav class="flex flex-col items-center justify-center flex-grow space-y-10 text-xl font-light tracking-wide">
             <a href="#articles" class="mobile-nav-link text-gray-400 hover:text-white transition">Archive</a>
-            <a href="#geolocation" class="mobile-nav-link text-gray-400 hover:text-white transition">Maps</a>
+            <a href="https://echoesofgaza.org/blog" class="mobile-nav-link text-gray-400 hover:text-white transition">Voices</a>
             <a href="#victims" class="mobile-nav-link text-gray-400 hover:text-white transition">Victims</a>
             <a href="#quotes" class="mobile-nav-link text-gray-400 hover:text-white transition">Resources</a>
+            <a href="#geolocation" class="mobile-nav-link text-gray-400 hover:text-white transition">Maps</a>
             <a href="https://echoesofgaza.org/events" class="mobile-nav-link text-gray-400 hover:text-white transition">Events</a>
             <a href="https://echoesofgaza.org/podcast"  class="mobile-nav-link text-gray-400 hover:text-white transition">EOG Podcast</a>
             <a href="./about.html" class="mobile-nav-link text-gray-400 hover:text-white transition">About</a>
@@ -5937,6 +5938,6 @@
             }
         });
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/indexLITE.html
+++ b/indexLITE.html
@@ -367,7 +367,7 @@
         .scrollbar-hide::-webkit-scrollbar { display: none; }
         .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 
 <body class="antialiased selection:bg-red-900 selection:text-white">
@@ -2045,6 +2045,6 @@ document.addEventListener('DOMContentLoaded', loadArticles);
             root.render(<StoryGenerator />);
         }
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/podcast.html
+++ b/podcast.html
@@ -148,7 +148,7 @@
             transform: translateY(0);
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="antialiased min-h-screen flex flex-col items-center">
 
@@ -437,6 +437,6 @@
             }, 2000);
         }
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/primary.html
+++ b/primary.html
@@ -106,7 +106,7 @@
             background-color: #601414;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="bg-void text-bone min-h-screen font-body selection:bg-blood selection:text-white antialiased">
 
@@ -696,6 +696,6 @@
         });
 
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/toolkit.html
+++ b/toolkit.html
@@ -107,7 +107,7 @@
             -webkit-box-decoration-break: clone;
         }
     </style>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
     <style>
         /* This page has a fixed left section sidebar; offset the shared site footer
            to clear it on desktop so the footer matches the layout of the main content. */
@@ -1155,6 +1155,6 @@
             setTimeout(updateNav, 100);
         });
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>

--- a/zionism_divide.html
+++ b/zionism_divide.html
@@ -222,7 +222,7 @@
         }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="./assets/site-shell.css?v=design-2">
+    <link rel="stylesheet" href="./assets/site-shell.css?v=nav-1">
 </head>
 <body class="antialiased pb-20">
 
@@ -768,6 +768,6 @@
     <script>
         lucide.createIcons();
     </script>
-    <script src="./assets/site-shell.js?v=about-1" defer></script>
+    <script src="./assets/site-shell.js?v=nav-1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed
- promoted Voices to the primary navigation position previously occupied by Maps
- moved Maps into Resources with the clearer label “Maps & Geolocation”
- applied the same hierarchy to the homepage, shared desktop header, mobile navigation, and footer resources
- added a slim gold current-page indicator for Voices pages
- bumped shared shell asset versions so returning visitors receive the updated navigation immediately

## Why
Voices is a primary reading destination and should be directly discoverable. Maps remains accessible as a specialized resource without competing for the main navigation’s limited attention.

## Validation
- `node --check assets/site-shell.js`
- HTML parser validation across affected pages
- `git diff --check`
- browser verification of desktop, mobile, and Resources ordering with no console errors

Unrelated local submission-script edits were excluded.