### PR TITLE
[codex] Add read-aloud controls to blog articles

### DIFF
--- a/assets/blog-audio-reader.css
+++ b/assets/blog-audio-reader.css
@@ -1,0 +1,149 @@
+.blog-audio-reader-mount {
+  margin-top: 1.25rem;
+}
+
+.blog-audio-reader {
+  display: flex;
+  align-items: stretch;
+  width: fit-content;
+  max-width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 8, 8, 0.7);
+}
+
+.blog-audio-reader-main,
+.blog-audio-reader-stop {
+  min-height: 48px;
+  border: 0;
+  color: #ededed;
+  cursor: pointer;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.blog-audio-reader-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 15rem;
+  padding: 0.65rem 0.85rem;
+  background: transparent;
+  text-align: left;
+}
+
+.blog-audio-reader-main:hover,
+.blog-audio-reader-main:focus-visible {
+  background: rgba(140, 13, 13, 0.1);
+}
+
+.blog-audio-reader-icon {
+  width: 1.6rem;
+  height: 1.6rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  color: #c44d4d;
+}
+
+.blog-audio-reader-icon svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.blog-audio-reader-copy {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.blog-audio-reader-label {
+  color: #ededed;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blog-audio-reader-status {
+  color: #7a7a7a;
+  font-size: 0.72rem;
+}
+
+.blog-audio-reader-stop {
+  padding: 0.65rem 0.9rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: #9b9690;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.blog-audio-reader-stop:hover,
+.blog-audio-reader-stop:focus-visible {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.blog-audio-reader-main:focus-visible,
+.blog-audio-reader-stop:focus-visible {
+  outline: 2px solid #c9a84c;
+  outline-offset: 2px;
+}
+
+.blog-audio-reader[data-reader-state="reading"] .blog-audio-reader-icon {
+  color: #ededed;
+}
+
+.blog-audio-reader[data-reader-state="reading"] .blog-audio-reader-icon::after {
+  content: "";
+  position: absolute;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid rgba(196, 77, 77, 0.55);
+  border-radius: 50%;
+  animation: blog-audio-pulse 1.5s ease-out infinite;
+}
+
+.blog-audio-reader-icon {
+  position: relative;
+}
+
+.blog-audio-reader-fallback {
+  margin: 0;
+  color: #8b8580;
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 0.8rem;
+}
+
+@keyframes blog-audio-pulse {
+  from { opacity: 0.7; transform: scale(0.75); }
+  to { opacity: 0; transform: scale(1.25); }
+}
+
+@media (max-width: 640px) {
+  .blog-audio-reader,
+  .blog-audio-reader-main {
+    width: 100%;
+  }
+
+  .blog-audio-reader-main {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .blog-audio-reader-stop {
+    flex: 0 0 auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-audio-reader[data-reader-state="reading"] .blog-audio-reader-icon::after {
+    animation: none;
+    display: none;
+  }
+}

--- a/assets/blog-audio-reader.js
+++ b/assets/blog-audio-reader.js
@@ -1,0 +1,216 @@
+(function () {
+  "use strict";
+
+  var synthesis = window.speechSynthesis;
+  var activeReader = null;
+
+  function normalizeText(value) {
+    return String(value || "").replace(/\s+/g, " ").trim();
+  }
+
+  function splitLongText(text, maxLength) {
+    var sentences = normalizeText(text).match(/[^.!?]+[.!?]+|[^.!?]+$/g) || [];
+    var chunks = [];
+    var current = "";
+
+    sentences.forEach(function (sentence) {
+      var next = normalizeText(current + " " + sentence);
+      if (next.length <= maxLength) {
+        current = next;
+        return;
+      }
+      if (current) chunks.push(current);
+      current = normalizeText(sentence);
+      while (current.length > maxLength) {
+        var cut = current.lastIndexOf(" ", maxLength);
+        if (cut < maxLength * 0.5) cut = maxLength;
+        chunks.push(current.slice(0, cut).trim());
+        current = current.slice(cut).trim();
+      }
+    });
+
+    if (current) chunks.push(current);
+    return chunks;
+  }
+
+  function extractArticleChunks(content) {
+    if (!content) return [];
+    var blocks = Array.from(content.querySelectorAll("h2, h3, p, blockquote, li"))
+      .filter(function (element) {
+        return !element.closest("[data-audio-reader-exclude], nav, footer, form, aside");
+      })
+      .map(function (element) {
+        return normalizeText(element.innerText || element.textContent);
+      })
+      .filter(Boolean);
+
+    if (!blocks.length) blocks = [normalizeText(content.innerText || content.textContent)].filter(Boolean);
+    return blocks.reduce(function (all, block) {
+      return all.concat(splitLongText(block, 900));
+    }, []);
+  }
+
+  function BlogAudioReader(options) {
+    this.root = options.root;
+    this.content = options.content;
+    this.language = options.language || "en-US";
+    this.rate = options.rate || 0.95;
+    this.chunks = [];
+    this.index = 0;
+    this.state = "idle";
+    this.utterance = null;
+    this.supported = Boolean(synthesis && window.SpeechSynthesisUtterance);
+    this.handlePageExit = this.stop.bind(this);
+    this.render();
+    this.bind();
+  }
+
+  BlogAudioReader.prototype.render = function () {
+    if (!this.supported) {
+      this.root.innerHTML =
+        '<p class="blog-audio-reader-fallback" role="status">Audio reading is not supported in this browser.</p>';
+      return;
+    }
+
+    this.root.innerHTML =
+      '<div class="blog-audio-reader" data-reader-state="idle">' +
+        '<button type="button" class="blog-audio-reader-main" data-audio-action="toggle" aria-label="Listen to this piece">' +
+          '<span class="blog-audio-reader-icon" aria-hidden="true">' +
+            '<svg viewBox="0 0 24 24"><path d="M8 9H4v6h4l5 4V5L8 9Z"></path><path d="M16 9.5a4 4 0 0 1 0 5"></path><path d="M18.5 7a7.5 7.5 0 0 1 0 10"></path></svg>' +
+          '</span>' +
+          '<span class="blog-audio-reader-copy">' +
+            '<span class="blog-audio-reader-label">Listen to this piece</span>' +
+            '<span class="blog-audio-reader-status" aria-live="polite">Play audio</span>' +
+          '</span>' +
+        '</button>' +
+        '<button type="button" class="blog-audio-reader-stop" data-audio-action="stop" hidden>Stop</button>' +
+      '</div>';
+  };
+
+  BlogAudioReader.prototype.bind = function () {
+    if (!this.supported) return;
+    var toggle = this.root.querySelector('[data-audio-action="toggle"]');
+    var stop = this.root.querySelector('[data-audio-action="stop"]');
+    toggle.addEventListener("click", this.toggle.bind(this));
+    stop.addEventListener("click", this.stop.bind(this));
+    window.addEventListener("pagehide", this.handlePageExit);
+    window.addEventListener("beforeunload", this.handlePageExit);
+  };
+
+  BlogAudioReader.prototype.setState = function (state) {
+    this.state = state;
+    var reader = this.root.querySelector(".blog-audio-reader");
+    var toggle = this.root.querySelector('[data-audio-action="toggle"]');
+    var stop = this.root.querySelector('[data-audio-action="stop"]');
+    var status = this.root.querySelector(".blog-audio-reader-status");
+    if (!reader || !toggle || !stop || !status) return;
+
+    reader.dataset.readerState = state;
+    stop.hidden = state === "idle";
+    if (state === "reading") {
+      status.textContent = "Pause";
+      toggle.setAttribute("aria-label", "Pause audio reading");
+    } else if (state === "paused") {
+      status.textContent = "Resume";
+      toggle.setAttribute("aria-label", "Resume audio reading");
+    } else {
+      status.textContent = "Play audio";
+      toggle.setAttribute("aria-label", "Listen to this piece");
+    }
+  };
+
+  BlogAudioReader.prototype.toggle = function () {
+    if (this.state === "reading") {
+      synthesis.pause();
+      this.setState("paused");
+      return;
+    }
+    if (this.state === "paused") {
+      synthesis.resume();
+      this.setState("reading");
+      return;
+    }
+    this.start();
+  };
+
+  BlogAudioReader.prototype.start = function () {
+    if (activeReader && activeReader !== this) activeReader.stop();
+    synthesis.cancel();
+    this.chunks = extractArticleChunks(this.content);
+    this.index = 0;
+    if (!this.chunks.length) {
+      var status = this.root.querySelector(".blog-audio-reader-status");
+      if (status) status.textContent = "No article text available";
+      return;
+    }
+    activeReader = this;
+    this.setState("reading");
+    this.speakNext();
+  };
+
+  BlogAudioReader.prototype.speakNext = function () {
+    var self = this;
+    if (this.state === "idle" || this.index >= this.chunks.length) {
+      this.finish();
+      return;
+    }
+
+    var utterance = new SpeechSynthesisUtterance(this.chunks[this.index]);
+    utterance.lang = this.language;
+    utterance.rate = this.rate;
+    utterance.onend = function () {
+      if (self.state === "idle") return;
+      self.index += 1;
+      self.speakNext();
+    };
+    utterance.onerror = function (event) {
+      if (event.error === "canceled" || event.error === "interrupted") return;
+      self.finish();
+      var status = self.root.querySelector(".blog-audio-reader-status");
+      if (status) status.textContent = "Audio could not start";
+    };
+    this.utterance = utterance;
+    synthesis.speak(utterance);
+  };
+
+  BlogAudioReader.prototype.finish = function () {
+    this.utterance = null;
+    this.index = 0;
+    if (activeReader === this) activeReader = null;
+    this.setState("idle");
+  };
+
+  BlogAudioReader.prototype.stop = function () {
+    if (this.supported) synthesis.cancel();
+    this.finish();
+  };
+
+  BlogAudioReader.prototype.destroy = function () {
+    this.stop();
+    window.removeEventListener("pagehide", this.handlePageExit);
+    window.removeEventListener("beforeunload", this.handlePageExit);
+    this.root.innerHTML = "";
+  };
+
+  window.BlogAudioReader = {
+    mount: function (options) {
+      if (activeReader) activeReader.destroy();
+      activeReader = new BlogAudioReader(options);
+      return activeReader;
+    },
+    stop: function () {
+      if (activeReader) activeReader.stop();
+      else if (synthesis) synthesis.cancel();
+    },
+    unmount: function () {
+      if (!activeReader) {
+        if (synthesis) synthesis.cancel();
+        return;
+      }
+      var reader = activeReader;
+      activeReader = null;
+      reader.destroy();
+    },
+    extractArticleChunks: extractArticleChunks
+  };
+})();

--- a/blog.html
+++ b/blog.html
@@ -19,6 +19,7 @@
     <meta name="twitter:title" content="Voices from Echoes of Gaza">
     <meta name="twitter:description" content="Stories, testimonies, and the lived consequences of standing for Palestine.">
     <meta name="twitter:image" content="https://i.postimg.cc/fT81SwN0/426559D6-9EF9-49AA-8A0B-84A3FA70B3E2.png">
+    <link rel="stylesheet" href="/assets/blog-audio-reader.css?v=1">
     <script>
         (function applyPostSpecificHeadMetadata() {
             const postSlug = new URLSearchParams(window.location.search).get("post");
@@ -778,6 +779,7 @@
     <div id="toast">Link copied to clipboard</div>
 
     <!-- JavaScript Logic -->
+    <script src="/assets/blog-audio-reader.js?v=1"></script>
     <script>
         // --- DATA STORE ---
         let posts = [
@@ -1770,6 +1772,7 @@
         }
 
         function renderIndex() {
+            window.BlogAudioReader?.unmount();
             window.scrollTo(0, 0);
             updatePostQuery(null);
             setSeoMeta(null);
@@ -1946,6 +1949,7 @@
                                 </div>
                             </div>
                         </div>
+                        <div id="blog-audio-reader" class="blog-audio-reader-mount" data-audio-reader-exclude></div>
                     </header>
 
                     <div class="blog-post-body">
@@ -2033,6 +2037,12 @@
                     </div>
                 </div>
             `;
+            window.BlogAudioReader?.mount({
+                root: document.getElementById("blog-audio-reader"),
+                content: document.querySelector(".prose-content"),
+                language: "en-US",
+                rate: 0.95
+            });
             loadBlogEngagement(post, true);
         }
 


### PR DESCRIPTION
## What changed
- added a reusable browser-native `BlogAudioReader` using the Web Speech API
- added Listen, Pause, Resume, and Stop states near each article byline
- limited speech extraction to the article’s `.prose-content` body
- split long pieces into manageable speech chunks for reliable playback
- stopped and cleaned up speech when leaving an article, returning to the index, or loading another piece
- added an unsupported-browser fallback message
- added responsive, accessible controls styled for the Echoes of Gaza Voices design

## Privacy and cost
Article text stays entirely in the browser and is not sent to an external API or paid service.

## Validation
- JavaScript syntax validation
- HTML parser validation
- `git diff --check`
- real article rendering with no console errors
- deterministic mocked speech tests for play, pause, resume, stop, unsupported-browser fallback, and article-body-only extraction

Unrelated local submission-script edits were excluded.